### PR TITLE
feat: make allow-root reads race-safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,6 +275,36 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "cap-primitives"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdadbd7c002d3a484b35243669abdae85a0ebaded5a61117169dc3400f9a7ff0"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "ipnet",
+ "maybe-owned",
+ "rustix",
+ "rustix-linux-procfs",
+ "windows-sys 0.61.2",
+ "winx",
+]
+
+[[package]]
+name = "cap-std"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7281235d6e96d3544ca18bba9049be92f4190f8d923e3caef1b5f66cfa752608"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "rustix",
+]
 
 [[package]]
 name = "castaway"
@@ -765,6 +801,7 @@ version = "0.2.3"
 dependencies = [
  "base64",
  "bpe-openai",
+ "cap-std",
  "chardetng",
  "clap",
  "crossterm",
@@ -871,6 +908,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes 2.0.4",
+ "rustix",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1324,6 +1372,34 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "io-extras"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
+dependencies = [
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "io-lifetimes"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2042,6 +2118,16 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -3047,6 +3133,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ pdf = ["dep:pdfium-render"]
 [dependencies]
 base64 = "0.22.1"
 bpe-openai = "0.3.0"
+cap-std = "4.0.2"
 chardetng = "1.0.0"
 clap = { version = "4.5.53", features = ["derive"] }
 crossterm = "0.29.0"

--- a/README.md
+++ b/README.md
@@ -358,6 +358,19 @@ The FastCtx MCP server inherits the local permissions of the host process.
 | TUI update check | Enabled for npm and GitHub Release launches | Version metadata from `registry.npmjs.org` and GitHub's `releases/latest` web redirect; downloads require explicit confirmation |
 | MCP runtime network requests | None | `serve` and tool calls perform no telemetry or update traffic |
 
+For a read-only candidate-filesystem boundary, start the server with one or more
+absolute `--allow-root` directories. The configured pathname namespace must be
+trusted and stable while FastCtx acquires those directory capabilities at
+startup. Restricted `read`, `batch`, `grep`, and `glob` requests then use only
+those capabilities and the file handles opened through them, so a runtime
+same-user rename or symlink swap cannot turn an authorized candidate into an
+out-of-root read. Existing project filtering is unchanged: FastCtx may read
+parent `.ignore` and `.gitignore` files, repository `.git/info/exclude`,
+gitfile `gitdir`/`commondir` metadata and their exclude file, and global Git
+configuration outside an allowed root. Those filtering-only reads can only omit
+candidates; they never authorize, return, or search candidate content. Without
+`--allow-root`, the historical unrestricted behavior is unchanged.
+
 The startup check sends the FastCtx version, normal HTTPS request metadata, and npm's standard registry request; it never sends repository paths, job data, or file contents. Background jobs persist their command, working directory, output, and exit status only in the current user's private `~/.fastctx/jobs/` directory; current-format jobs use a complete plain log. FastCtx does not upload this data. Bash commands can access the network according to the command itself. Prebuilt binaries include the PDF engine.
 
 The MCP server runs outside the host filesystem sandbox. Use an approval mode when every write and command execution should be reviewed:

--- a/README.md
+++ b/README.md
@@ -369,7 +369,9 @@ parent `.ignore` and `.gitignore` files, repository `.git/info/exclude`,
 gitfile `gitdir`/`commondir` metadata and their exclude file, and global Git
 configuration outside an allowed root. Those filtering-only reads can only omit
 candidates; they never authorize, return, or search candidate content. Without
-`--allow-root`, the historical unrestricted behavior is unchanged.
+`--allow-root`, requested paths remain unrestricted, while each file operation
+uses one capability-opened handle so later pathname replacement cannot redirect
+that operation's content read.
 
 The startup check sends the FastCtx version, normal HTTPS request metadata, and npm's standard registry request; it never sends repository paths, job data, or file contents. Background jobs persist their command, working directory, output, and exit status only in the current user's private `~/.fastctx/jobs/` directory; current-format jobs use a complete plain log. FastCtx does not upload this data. Bash commands can access the network according to the command itself. Prebuilt binaries include the PDF engine.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -354,6 +354,16 @@ FastCtx MCP server 继承宿主进程的本地权限。
 | TUI 更新检查 | npm 与 GitHub Release 启动时开启 | 从 `registry.npmjs.org` 与 GitHub 的 `releases/latest` 网页重定向获取版本元数据；下载必须由用户确认 |
 | MCP runtime 网络请求 | 无 | `serve` 与工具调用不产生遥测或更新流量 |
 
+如需只读候选文件系统边界，请使用一个或多个绝对路径的 `--allow-root`
+启动服务器。FastCtx 在启动时获取这些目录能力；此时配置路径所在的命名空间
+必须可信且保持稳定。之后，受限的 `read`、`batch`、`grep` 和 `glob`
+请求只通过这些能力及其打开的文件句柄执行，因此运行期间同一用户的重命名或
+符号链接替换不会把已授权候选文件变成根目录外读取。现有项目过滤行为保持
+不变：FastCtx 仍可能从允许根目录外读取父级 `.ignore`、`.gitignore`、仓库
+`.git/info/exclude`、gitfile 的 `gitdir`/`commondir` 元数据及其 exclude 文件，
+以及全局 Git 配置。这些只用于过滤的读取只能排除候选项，绝不会授予读取、返回
+或搜索候选内容的权限。不指定 `--allow-root` 时，历史上的不受限行为保持不变。
+
 启动检查只会发送 FastCtx 版本、常规 HTTPS 请求元数据，以及 npm 的标准仓库请求；不会发送仓库路径、任务数据或文件内容。后台任务的命令、工作目录、输出与退出状态只保存在当前用户的私有目录 `~/.fastctx/jobs/` 中；当前格式任务使用完整纯文本日志。FastCtx 不会上传这些数据。Bash 命令仍可按照命令本身访问网络。预构建版本已经内嵌 PDF 引擎。
 
 MCP server 位于宿主文件沙箱之外。需要逐次确认写入和命令执行时，可以配置：

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -8,6 +8,7 @@ use crate::control::i18n::{ALL_LANGUAGES, Language};
 use crate::control::paths::ControlPaths;
 use crate::control::settings::{self, Tier};
 use crate::file_executor::GrepGlobExecutor;
+use crate::paths::ReadScope;
 use crate::server::{FastCtxServer, ServerOptions};
 use clap::{Parser, Subcommand};
 use rmcp::ServiceExt;
@@ -42,6 +43,9 @@ enum Command {
         /// Deprecated compatibility flag; replace is always published.
         #[arg(long, hide = true)]
         enable_edit: bool,
+        /// Restrict all read, grep, and glob targets to this directory; repeatable.
+        #[arg(long = "allow-root", value_name = "PATH")]
+        allow_roots: Vec<PathBuf>,
     },
     /// Force the full-screen control terminal.
     Ui,
@@ -153,7 +157,11 @@ async fn run_cli(cli: Cli) -> Result<ExitCode, String> {
         Some(Command::Serve {
             enable_shell,
             enable_edit: _,
-        }) => run_server_with_options(ServerOptions { enable_shell }).await,
+            allow_roots,
+        }) => {
+            let scope = ReadScope::from_allow_roots(&allow_roots)?;
+            run_server_with_options_and_scope(ServerOptions { enable_shell }, scope).await
+        }
         Some(Command::Ui) => {
             require_tty()?;
             let paths = ControlPaths::discover()?;
@@ -289,11 +297,26 @@ pub async fn run_server() -> Result<ExitCode, String> {
 
 /// Starts the single server with the requested optional tool groups.
 pub async fn run_server_with_options(options: ServerOptions) -> Result<ExitCode, String> {
+    run_server_with_options_and_scope(options, ReadScope::unrestricted()).await
+}
+
+pub(crate) async fn run_server_with_options_and_scope(
+    options: ServerOptions,
+    scope: ReadScope,
+) -> Result<ExitCode, String> {
     let paths = ControlPaths::discover()?;
     let executor = load_search_executor(&paths)?;
     let parent = crate::process_identity::parent_identity_from_environment()?;
     let stdin = crate::stdio_transport::DetachedStdin::start()?;
-    run_server_with_io_and_executor(options, parent, stdin, tokio::io::stdout(), executor).await
+    run_server_with_io_and_executor_and_scope(
+        options,
+        parent,
+        stdin,
+        tokio::io::stdout(),
+        executor,
+        scope,
+    )
+    .await
 }
 
 fn load_search_executor(paths: &ControlPaths) -> Result<Arc<GrepGlobExecutor>, String> {
@@ -319,16 +342,24 @@ async fn run_server_with_io<W>(
 where
     W: tokio::io::AsyncWrite + Send + Unpin + 'static,
 {
-    run_server_with_io_and_executor(options, parent, stdin, stdout, GrepGlobExecutor::shared())
-        .await
+    run_server_with_io_and_executor_and_scope(
+        options,
+        parent,
+        stdin,
+        stdout,
+        GrepGlobExecutor::shared(),
+        ReadScope::unrestricted(),
+    )
+    .await
 }
 
-async fn run_server_with_io_and_executor<W>(
+async fn run_server_with_io_and_executor_and_scope<W>(
     options: ServerOptions,
     parent: Option<Option<crate::process_identity::ProcessIdentity>>,
     stdin: crate::stdio_transport::DetachedStdin,
     stdout: W,
     executor: Arc<GrepGlobExecutor>,
+    scope: ReadScope,
 ) -> Result<ExitCode, String>
 where
     W: tokio::io::AsyncWrite + Send + Unpin + 'static,
@@ -337,7 +368,7 @@ where
     let stdin_read_error = stdin.read_error_receiver();
     let stdin_read_error_wait = wait_for_stdin_read_error(stdin_read_error.clone());
     tokio::pin!(stdin_read_error_wait);
-    let service = match FastCtxServer::with_options_and_executor(options, executor)
+    let service = match FastCtxServer::with_options_and_executor_and_scope(options, executor, scope)
         .serve((stdin, stdout))
         .await
     {
@@ -702,7 +733,7 @@ fn print_receipt(receipt: &crate::control::apply::OperationReceipt) {
 
 #[cfg(test)]
 mod tests {
-    use super::{ServerOptions, load_search_executor, run_server_with_io};
+    use super::{Cli, Command, ServerOptions, load_search_executor, run_cli, run_server_with_io};
     use crate::control::paths::ControlPaths;
     use crate::stdio_transport::DetachedStdin;
     use std::io::{Cursor, Read};
@@ -792,6 +823,22 @@ mod tests {
         assert_eq!(
             result.unwrap_err(),
             "Cannot read MCP stdin: injected established-session stdin failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn serve_validates_allow_roots_before_starting_the_server() {
+        let result = run_cli(Cli {
+            command: Some(Command::Serve {
+                enable_shell: false,
+                enable_edit: false,
+                allow_roots: vec![std::path::PathBuf::from("relative-root")],
+            }),
+        })
+        .await;
+        assert_eq!(
+            result.unwrap_err(),
+            "Invalid --allow-root relative-root: the path must be absolute."
         );
     }
 }

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -166,15 +166,6 @@ impl ValidatedFileEncoding {
         decode_bytes(raw, &self.detected).map(|text| std::borrow::Cow::Owned(text.into_bytes()))
     }
 
-    /// Streams UTF-8 text on character boundaries and stops immediately when the callback returns false.
-    pub(crate) fn stream_text(
-        &self,
-        path: &Path,
-        on_text: impl FnMut(&str) -> bool,
-    ) -> Result<bool, StreamDecodeFailure> {
-        self.stream_source(ByteSource::File(path), on_text)
-    }
-
     /// Streams decoded text from the supplied source without choosing a new
     /// pathname.
     pub(crate) fn stream_source(

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -31,7 +31,7 @@ const FIXED_LEGACY_ENCODINGS: [(&str, &Encoding); 5] = [
     ("euc-kr", EUC_KR),
 ];
 
-/// One validation input: an on-disk file or an immutable byte snapshot.
+/// One validation input: an on-disk file, an already-authorized file handle, or an immutable byte snapshot.
 ///
 /// Both variants drive the exact same chunked validation machinery, so the
 /// trust hierarchy has a single implementation. Grep uses `Snapshot` so every
@@ -39,12 +39,14 @@ const FIXED_LEGACY_ENCODINGS: [(&str, &Encoding); 5] = [
 #[derive(Clone, Copy)]
 pub(crate) enum ByteSource<'a> {
     File(&'a Path),
+    Handle(&'a File),
     Bytes(&'a [u8]),
     Snapshot(&'a SealedSnapshot),
 }
 
 enum SourceReader<'a> {
     File(BufReader<File>),
+    Handle(BufReader<File>),
     Bytes(io::Cursor<&'a [u8]>),
     Snapshot(SnapshotReader<'a>),
 }
@@ -53,6 +55,7 @@ impl<'a> SourceReader<'a> {
     fn open(source: ByteSource<'a>, start: u64) -> io::Result<Self> {
         match source {
             ByteSource::File(path) => Ok(Self::open_file(path, start)?),
+            ByteSource::Handle(file) => Ok(Self::open_handle(file, start)?),
             ByteSource::Bytes(bytes) => {
                 let start = usize::try_from(start)
                     .unwrap_or(usize::MAX)
@@ -72,12 +75,19 @@ impl<'a> SourceReader<'a> {
         }
         Ok(SourceReader::File(reader))
     }
+
+    fn open_handle(file: &File, start: u64) -> io::Result<SourceReader<'static>> {
+        let mut reader = BufReader::new(file.try_clone()?);
+        reader.seek(SeekFrom::Start(start))?;
+        Ok(SourceReader::Handle(reader))
+    }
 }
 
 impl Read for SourceReader<'_> {
     fn read(&mut self, output: &mut [u8]) -> io::Result<usize> {
         match self {
             SourceReader::File(reader) => reader.read(output),
+            SourceReader::Handle(reader) => reader.read(output),
             SourceReader::Bytes(cursor) => cursor.read(output),
             SourceReader::Snapshot(reader) => reader.read(output),
         }
@@ -160,9 +170,19 @@ impl ValidatedFileEncoding {
     pub(crate) fn stream_text(
         &self,
         path: &Path,
+        on_text: impl FnMut(&str) -> bool,
+    ) -> Result<bool, StreamDecodeFailure> {
+        self.stream_source(ByteSource::File(path), on_text)
+    }
+
+    /// Streams decoded text from the supplied source without choosing a new
+    /// pathname.
+    pub(crate) fn stream_source(
+        &self,
+        source: ByteSource<'_>,
         mut on_text: impl FnMut(&str) -> bool,
     ) -> Result<bool, StreamDecodeFailure> {
-        let mut decoder = DecodedChunkReader::open(ByteSource::File(path), self.detected.clone())?;
+        let mut decoder = DecodedChunkReader::open(source, self.detected.clone())?;
         loop {
             match decoder.next_chunk()? {
                 Some(chunk) if !on_text(&chunk) => return Ok(false),

--- a/src/encoding/snapshot_pipeline.rs
+++ b/src/encoding/snapshot_pipeline.rs
@@ -66,7 +66,7 @@ pub(super) fn validate_source(
                 })
             }
         }
-        ByteSource::File(_) => read_prefix(source, operation)
+        ByteSource::File(_) | ByteSource::Handle(_) => read_prefix(source, operation)
             .and_then(|prefix| validate_with_prefix(source, &prefix, explicit_encoding, operation)),
     };
     prefer_stop(operation, result)

--- a/src/file_snapshot.rs
+++ b/src/file_snapshot.rs
@@ -9,6 +9,7 @@ use crate::operation::{WorkCheckpoint, WorkStop};
 use crate::path_codec::{FileIdentityHint, PathRecord};
 use std::fs::File;
 use std::io::{self, BufReader, Cursor, Read, Seek, SeekFrom, Write};
+#[cfg(test)]
 use std::path::Path;
 use std::sync::Arc;
 
@@ -709,6 +710,11 @@ pub(crate) fn capture_classify_open_file(
     }
     let capture = capture_reader(&mut file, explicit_encoding, fallback_encoding, operation)?;
     checkpoint(operation)?;
+    #[cfg(test)]
+    if let Some(operation) = operation {
+        operation.stage(crate::operation::TestStage::BeforeIdentityPostCheck);
+    }
+    checkpoint(operation)?;
     let (after, is_regular) = identity_from_file(&file)
         .map_err(|error| prefer_stop(operation, CaptureFailure::Io(error)))?;
     if !is_regular || !before.same_state_for_authorized_capture(&after) {
@@ -745,12 +751,12 @@ fn prefer_stop(operation: Option<&dyn WorkCheckpoint>, failure: CaptureFailure) 
     }
 }
 
-#[cfg(not(windows))]
+#[cfg(all(test, not(windows)))]
 fn open_original(path: &Path) -> io::Result<File> {
     File::open(path)
 }
 
-#[cfg(windows)]
+#[cfg(all(test, windows))]
 fn open_original(path: &Path) -> io::Result<File> {
     use std::os::windows::fs::OpenOptionsExt;
     use windows_sys::Win32::Storage::FileSystem::{
@@ -765,6 +771,7 @@ fn open_original(path: &Path) -> io::Result<File> {
 }
 
 /// Opens the original candidate once, captures its bytes, and verifies stable identity.
+#[cfg(test)]
 pub(crate) fn capture_classify(
     candidate: &PathRecord,
     explicit_encoding: Option<&str>,
@@ -891,7 +898,7 @@ fn identity_from_file(file: &File) -> io::Result<(FileIdentity, bool)> {
     Ok((FileIdentity::from_metadata(&metadata), metadata.is_file()))
 }
 
-#[cfg(unix)]
+#[cfg(all(test, unix))]
 fn identity_from_path(path: &Path) -> io::Result<(FileIdentity, bool)> {
     let metadata = std::fs::metadata(path)?;
     Ok((FileIdentity::from_metadata(&metadata), metadata.is_file()))
@@ -1026,7 +1033,7 @@ fn identity_from_file(file: &File) -> io::Result<(FileIdentity, bool)> {
     Ok((FileIdentity::from_file(file)?, metadata.is_file()))
 }
 
-#[cfg(windows)]
+#[cfg(all(test, windows))]
 fn identity_from_path(path: &Path) -> io::Result<(FileIdentity, bool)> {
     use std::os::windows::fs::OpenOptionsExt;
     use windows_sys::Win32::Storage::FileSystem::{

--- a/src/file_snapshot.rs
+++ b/src/file_snapshot.rs
@@ -98,15 +98,6 @@ impl Read for SnapshotReader<'_> {
     }
 }
 
-impl Seek for SnapshotReader<'_> {
-    fn seek(&mut self, position: SeekFrom) -> io::Result<u64> {
-        match self {
-            Self::Memory(reader) => reader.seek(position),
-            Self::Temp(reader) => reader.seek(position),
-        }
-    }
-}
-
 #[derive(Debug)]
 struct TempSnapshot {
     file: tempfile::NamedTempFile,

--- a/src/file_snapshot.rs
+++ b/src/file_snapshot.rs
@@ -98,6 +98,15 @@ impl Read for SnapshotReader<'_> {
     }
 }
 
+impl Seek for SnapshotReader<'_> {
+    fn seek(&mut self, position: SeekFrom) -> io::Result<u64> {
+        match self {
+            Self::Memory(reader) => reader.seek(position),
+            Self::Temp(reader) => reader.seek(position),
+        }
+    }
+}
+
 #[derive(Debug)]
 struct TempSnapshot {
     file: tempfile::NamedTempFile,
@@ -690,6 +699,46 @@ fn capture_reader(
     builder.finish(operation).map(CaptureRead::Complete)
 }
 
+/// Classifies and captures an already-authorized file handle without reopening
+/// its pathname. The handle stays pinned to the routed capability target.
+pub(crate) fn capture_classify_open_file(
+    mut file: File,
+    candidate: PathRecord,
+    explicit_encoding: Option<&str>,
+    fallback_encoding: Option<&str>,
+    operation: Option<&dyn WorkCheckpoint>,
+) -> Result<CaptureDisposition, CaptureFailure> {
+    checkpoint(operation)?;
+    let (before, is_regular) = identity_from_file(&file)
+        .map_err(|error| prefer_stop(operation, CaptureFailure::Io(error)))?;
+    #[cfg(test)]
+    tests::notify_original_open(&candidate.native);
+    if !is_regular || !before.matches_hint(candidate.traversal_fingerprint.as_ref()) {
+        return Ok(CaptureDisposition::FileChanged);
+    }
+    let capture = capture_reader(&mut file, explicit_encoding, fallback_encoding, operation)?;
+    checkpoint(operation)?;
+    let (after, is_regular) = identity_from_file(&file)
+        .map_err(|error| prefer_stop(operation, CaptureFailure::Io(error)))?;
+    if !is_regular || !before.same_state_for_authorized_capture(&after) {
+        return Ok(CaptureDisposition::FileChanged);
+    }
+    Ok(match capture {
+        CaptureRead::Terminal(proof) => match proof.rejection() {
+            Some(rejection) => CaptureDisposition::EncodingRejected { rejection, proof },
+            None => CaptureDisposition::BinarySkipped(proof),
+        },
+        CaptureRead::Complete(captured) => {
+            CaptureDisposition::Searchable(Box::new(SealedSnapshot {
+                path: candidate,
+                _before: before,
+                _after: after,
+                captured,
+            }))
+        }
+    })
+}
+
 fn checkpoint(operation: Option<&dyn WorkCheckpoint>) -> Result<(), CaptureFailure> {
     match operation.map(WorkCheckpoint::check_work) {
         Some(Err(WorkStop::RequestCancelled)) => Err(CaptureFailure::Cancelled),
@@ -839,6 +888,10 @@ impl FileIdentity {
     fn same_state(&self, other: &Self) -> bool {
         self == other
     }
+
+    fn same_state_for_authorized_capture(&self, other: &Self) -> bool {
+        self.same_state(other)
+    }
 }
 
 #[cfg(unix)]
@@ -965,6 +1018,10 @@ impl FileIdentity {
                 _ => true,
             }
     }
+
+    fn same_state_for_authorized_capture(&self, other: &Self) -> bool {
+        self.change_time.is_some() && other.change_time.is_some() && self.same_state(other)
+    }
 }
 
 #[cfg(windows)]
@@ -995,12 +1052,14 @@ fn identity_from_path(path: &Path) -> io::Result<(FileIdentity, bool)> {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::{
         CaptureDisposition, CaptureFailure, CaptureRead, FallbackTerminalState,
         MEMORY_SNAPSHOT_LIMIT, PREFLIGHT_BYTES, SNAPSHOT_CHUNK_BYTES, SnapshotBuilder,
         TerminalProof, capture_classify, capture_reader,
     };
+    #[cfg(windows)]
+    use super::{FileIdentity, WindowsFileId};
     use crate::encoding::{
         ByteSource, EncodingDecision, EncodingRejection, validate_source_encoding,
     };
@@ -1017,12 +1076,31 @@ mod tests {
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use tokio_util::sync::CancellationToken;
 
-    type TempCreateCallback = Arc<dyn Fn(&Path)>;
-    type OriginalOpenCallback = Arc<dyn Fn(&Path)>;
+    pub(crate) type TempCreateCallback = Arc<dyn Fn(&Path)>;
+    pub(crate) type OriginalOpenCallback = Arc<dyn Fn(&Path)>;
 
     thread_local! {
         static TEMP_CREATE_OBSERVER: RefCell<Option<TempCreateCallback>> = RefCell::new(None);
         static ORIGINAL_OPEN_OBSERVER: RefCell<Option<OriginalOpenCallback>> = RefCell::new(None);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn authorized_capture_requires_windows_change_time_proof() {
+        let identity = FileIdentity {
+            file_id: WindowsFileId::Legacy {
+                volume_serial: 1,
+                file_index: 2,
+            },
+            len: 3,
+            creation_time: 4,
+            last_write_time: 5,
+            change_time: None,
+            attributes: 6,
+        };
+
+        assert!(identity.same_state(&identity));
+        assert!(!identity.same_state_for_authorized_capture(&identity));
     }
 
     pub(super) fn notify_temp_created(path: &Path) {
@@ -1032,17 +1110,17 @@ mod tests {
         }
     }
 
-    pub(super) fn notify_original_open(path: &Path) {
+    pub(crate) fn notify_original_open(path: &Path) {
         let observer = ORIGINAL_OPEN_OBSERVER.with(|slot| slot.borrow().clone());
         if let Some(observer) = observer {
             observer(path);
         }
     }
 
-    struct TempCreateObserverGuard;
+    pub(crate) struct TempCreateObserverGuard;
 
     impl TempCreateObserverGuard {
-        fn install(observer: TempCreateCallback) -> Self {
+        pub(crate) fn install(observer: TempCreateCallback) -> Self {
             TEMP_CREATE_OBSERVER.with(|slot| {
                 assert!(
                     slot.borrow_mut().replace(observer).is_none(),
@@ -1061,10 +1139,10 @@ mod tests {
         }
     }
 
-    struct OriginalOpenObserverGuard;
+    pub(crate) struct OriginalOpenObserverGuard;
 
     impl OriginalOpenObserverGuard {
-        fn install(observer: OriginalOpenCallback) -> Self {
+        pub(crate) fn install(observer: OriginalOpenCallback) -> Self {
             ORIGINAL_OPEN_OBSERVER.with(|slot| {
                 assert!(
                     slot.borrow_mut().replace(observer).is_none(),

--- a/src/glob_tool.rs
+++ b/src/glob_tool.rs
@@ -235,6 +235,30 @@ fn collect_matches(
     if operation.check().is_err() {
         return Err("Request cancelled.".to_string());
     }
+    if root.scope.is_restricted() {
+        let candidates = crate::traversal::collect_capability_candidates_filtered(
+            root,
+            Some(matcher),
+            None,
+            Some(operation),
+            crate::traversal::CapabilityCandidateOptions {
+                honor_ignore: filter_mode == FilterMode::Project,
+                detail: if sort == SortMode::Path {
+                    crate::traversal::CandidateDetail::Path
+                } else {
+                    crate::traversal::CandidateDetail::Metadata
+                },
+                limit: Some(MAX_RESULTS),
+                limit_message: TOO_MANY_MATCHES_ERROR,
+            },
+        )?;
+        let mut matches = candidates
+            .into_iter()
+            .map(|path| MatchEntry { path })
+            .collect::<Vec<_>>();
+        matches.sort_by(|left, right| compare_match_entries(sort, left, right));
+        return Ok(matches);
+    }
     let mut builder = WalkBuilder::new(&root.native);
     match filter_mode {
         FilterMode::Project => {
@@ -570,8 +594,10 @@ mod tests {
     use crate::render_plan::RenderPlanMetrics;
     use crate::{ToolContent, ToolResponse};
     use rmcp::model::RequestId;
+    use std::env;
     use std::fs;
     use std::path::Path;
+    use std::process::Command;
     use std::sync::Arc;
     use std::sync::atomic::Ordering;
     use std::time::SystemTime;
@@ -877,6 +903,647 @@ mod tests {
         assert!(text.starts_with("Permission denied: "), "{text}");
     }
 
+    #[test]
+    fn restricted_glob_preserves_nested_ignore_and_filter_mode_semantics() {
+        let fixture = tempfile::tempdir().unwrap();
+        let workspace = fixture.path().join("workspace");
+        let root = workspace.join("project");
+        let nested = root.join("nested");
+        fs::create_dir_all(&nested).unwrap();
+        fs::write(workspace.join(".gitignore"), "parent-git.txt\n").unwrap();
+        fs::write(workspace.join(".ignore"), "parent-ignore.txt\n").unwrap();
+        fs::create_dir_all(workspace.join(".git/info")).unwrap();
+        fs::write(workspace.join(".git/info/exclude"), "excluded.txt\n").unwrap();
+        fs::write(root.join(".gitignore"), "ignored-git.txt\nnested/*.tmp\n").unwrap();
+        fs::write(root.join(".ignore"), "ignored-ignore.txt\n").unwrap();
+        fs::write(nested.join(".gitignore"), "*.tmp\n!keep.tmp\n").unwrap();
+        fs::write(root.join("visible.txt"), b"visible").unwrap();
+        fs::write(root.join(".hidden.txt"), b"hidden").unwrap();
+        fs::write(root.join("ignored-git.txt"), b"git").unwrap();
+        fs::write(root.join("ignored-ignore.txt"), b"ignore").unwrap();
+        fs::write(root.join("parent-git.txt"), b"parent").unwrap();
+        fs::write(root.join("parent-ignore.txt"), b"parent").unwrap();
+        fs::write(root.join("excluded.txt"), b"excluded").unwrap();
+        fs::write(nested.join("keep.txt"), b"keep").unwrap();
+        fs::write(nested.join("drop.tmp"), b"drop").unwrap();
+        fs::write(nested.join("keep.tmp"), b"keep").unwrap();
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&workspace)).unwrap();
+        let request = |filter_mode| GlobRequest {
+            pattern: "**/*".to_string(),
+            path: Some(root.to_string_lossy().into_owned()),
+            filter_mode: Some(filter_mode),
+            sort: Some(SortMode::Path),
+            offset: None,
+            limit: None,
+        };
+        let project = glob_files_with_scope(
+            request(FilterMode::Project),
+            CancellationToken::new(),
+            &scope,
+        );
+        let unrestricted = glob_files_with_scope(
+            request(FilterMode::Project),
+            CancellationToken::new(),
+            &ReadScope::unrestricted(),
+        );
+        let all = glob_files_with_scope(request(FilterMode::All), CancellationToken::new(), &scope);
+        let ToolContent::Text(project_text) = &project.content[0] else {
+            panic!("expected project response: {project:?}");
+        };
+        let ToolContent::Text(all_text) = &all.content[0] else {
+            panic!("expected all response: {all:?}");
+        };
+        let ToolContent::Text(unrestricted_text) = &unrestricted.content[0] else {
+            panic!("expected unrestricted response: {unrestricted:?}");
+        };
+        assert_eq!(project_text, unrestricted_text);
+        assert!(project_text.contains("visible.txt"), "{project_text}");
+        assert!(project_text.contains(".hidden.txt"), "{project_text}");
+        assert!(project_text.contains("keep.txt"), "{project_text}");
+        assert!(project_text.contains("keep.tmp"), "{project_text}");
+        assert!(!project_text.contains("ignored-git.txt"), "{project_text}");
+        assert!(
+            !project_text.contains("ignored-ignore.txt"),
+            "{project_text}"
+        );
+        assert!(!project_text.contains("drop.tmp"), "{project_text}");
+        for name in ["parent-git.txt", "parent-ignore.txt", "excluded.txt"] {
+            assert!(!project_text.contains(name), "{project_text}");
+        }
+        for name in [
+            "visible.txt",
+            ".hidden.txt",
+            "ignored-git.txt",
+            "ignored-ignore.txt",
+            "keep.txt",
+            "drop.tmp",
+            "keep.tmp",
+            "parent-git.txt",
+            "parent-ignore.txt",
+            "excluded.txt",
+        ] {
+            assert!(all_text.contains(name), "{all_text}");
+        }
+    }
+
+    #[test]
+    fn restricted_project_walk_reads_parent_rules_when_nested_allow_root_wins() {
+        let fixture = tempfile::tempdir().unwrap();
+        let repository = fixture.path().join("repository");
+        let root = repository.join("subdir");
+        fs::create_dir_all(repository.join(".git/info")).unwrap();
+        fs::create_dir(&root).unwrap();
+        fs::write(repository.join(".ignore"), "/subdir/parent-ignore.txt\n").unwrap();
+        fs::write(
+            repository.join(".gitignore"),
+            "/subdir/parent-gitignore.txt\n",
+        )
+        .unwrap();
+        fs::write(
+            repository.join(".git/info/exclude"),
+            "subdir/parent-exclude.txt\n",
+        )
+        .unwrap();
+        for name in [
+            "parent-ignore.txt",
+            "parent-gitignore.txt",
+            "parent-exclude.txt",
+            "visible.txt",
+        ] {
+            fs::write(root.join(name), b"fixture").unwrap();
+        }
+
+        // The longest matching configured root is `subdir`, so every rule is
+        // outside its capability and must be loaded as filtering-only config.
+        let scope = ReadScope::from_allow_roots(&[repository, root.clone()]).unwrap();
+        let request = GlobRequest {
+            pattern: "*.txt".to_string(),
+            path: Some(root.to_string_lossy().into_owned()),
+            filter_mode: Some(FilterMode::Project),
+            sort: Some(SortMode::Path),
+            offset: None,
+            limit: None,
+        };
+        let restricted = glob_files_with_scope(request.clone(), CancellationToken::new(), &scope);
+        let unrestricted = glob_files_with_scope(
+            request,
+            CancellationToken::new(),
+            &ReadScope::unrestricted(),
+        );
+        assert_eq!(restricted, unrestricted);
+        let text = response_path_lines(&restricted).join("\n");
+        assert!(text.contains("visible.txt"), "{text}");
+        for hidden in [
+            "parent-ignore.txt",
+            "parent-gitignore.txt",
+            "parent-exclude.txt",
+        ] {
+            assert!(!text.contains(hidden), "{text}");
+        }
+    }
+
+    #[test]
+    fn restricted_project_walk_reads_relative_gitdir_commondir_exclude_outside_root() {
+        let fixture = tempfile::tempdir().unwrap();
+        let common = fixture.path().join("common");
+        let gitdir = common.join(".git/worktrees/checked-out");
+        let root = fixture.path().join("worktree");
+        fs::create_dir_all(common.join(".git/info")).unwrap();
+        fs::create_dir_all(&gitdir).unwrap();
+        fs::create_dir(&root).unwrap();
+        fs::write(
+            root.join(".git"),
+            "gitdir: ../common/.git/worktrees/checked-out\n",
+        )
+        .unwrap();
+        fs::write(gitdir.join("commondir"), "../..\n").unwrap();
+        fs::write(common.join(".git/info/exclude"), "excluded.txt\n").unwrap();
+        fs::write(root.join("excluded.txt"), b"excluded").unwrap();
+        fs::write(root.join("visible.txt"), b"visible").unwrap();
+
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+        let request = GlobRequest {
+            pattern: "*.txt".to_string(),
+            path: Some(root.to_string_lossy().into_owned()),
+            filter_mode: Some(FilterMode::Project),
+            sort: Some(SortMode::Path),
+            offset: None,
+            limit: None,
+        };
+        let restricted = glob_files_with_scope(request, CancellationToken::new(), &scope);
+        let text = response_path_lines(&restricted).join("\n");
+        assert!(text.contains("visible.txt"), "{text}");
+        assert!(!text.contains("excluded.txt"), "{text}");
+    }
+
+    #[test]
+    fn restricted_project_walk_uses_gitdir_exclude_when_commondir_is_absent() {
+        let fixture = tempfile::tempdir().unwrap();
+        let gitdir = fixture.path().join("gitdir");
+        let root = fixture.path().join("worktree");
+        fs::create_dir_all(gitdir.join("info")).unwrap();
+        fs::create_dir(&root).unwrap();
+        fs::write(root.join(".git"), "gitdir: ../gitdir\n").unwrap();
+        fs::write(gitdir.join("info/exclude"), "excluded.txt\n").unwrap();
+        fs::write(root.join("excluded.txt"), b"excluded").unwrap();
+        fs::write(root.join("visible.txt"), b"visible").unwrap();
+
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+        let request = GlobRequest {
+            pattern: "*.txt".to_string(),
+            path: Some(root.to_string_lossy().into_owned()),
+            filter_mode: Some(FilterMode::Project),
+            sort: Some(SortMode::Path),
+            offset: None,
+            limit: None,
+        };
+        let restricted = glob_files_with_scope(request, CancellationToken::new(), &scope);
+        let text = response_path_lines(&restricted).join("\n");
+        assert!(text.contains("visible.txt"), "{text}");
+        assert!(!text.contains("excluded.txt"), "{text}");
+    }
+
+    #[test]
+    fn malformed_parent_ignore_never_exposes_its_pattern() {
+        let fixture = tempfile::tempdir().unwrap();
+        let parent = fixture.path().join("parent");
+        let root = parent.join("root");
+        fs::create_dir(&parent).unwrap();
+        fs::create_dir(&root).unwrap();
+        let secret = "synthetic-secret-ignore-pattern";
+        fs::write(parent.join(".ignore"), format!("[{secret}\nhidden.txt\n")).unwrap();
+        fs::write(root.join("hidden.txt"), b"hidden").unwrap();
+        fs::write(root.join("visible.txt"), b"visible").unwrap();
+
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+        let response = glob_files_with_scope(
+            GlobRequest {
+                pattern: "*.txt".to_string(),
+                path: Some(root.to_string_lossy().into_owned()),
+                filter_mode: Some(FilterMode::Project),
+                sort: Some(SortMode::Path),
+                offset: None,
+                limit: None,
+            },
+            CancellationToken::new(),
+            &scope,
+        );
+        let ToolContent::Text(text) = &response.content[0] else {
+            panic!("expected text response: {response:?}");
+        };
+        assert!(!text.contains(secret), "{text}");
+        assert!(text.contains("visible.txt"), "{text}");
+        assert!(!text.contains("hidden.txt"), "{text}");
+    }
+
+    #[test]
+    fn restricted_glob_accepts_ignore_config_at_the_size_limit() {
+        let fixture = tempfile::tempdir().unwrap();
+        let root = fixture.path().join("root");
+        fs::create_dir(&root).unwrap();
+        let rule = "hidden.txt\n";
+        let contents = format!(
+            "{rule}#{}",
+            "x".repeat(crate::traversal::MAX_IGNORE_CONFIG_BYTES - rule.len() - 1)
+        );
+        assert_eq!(contents.len(), crate::traversal::MAX_IGNORE_CONFIG_BYTES);
+        fs::write(root.join(".ignore"), contents).unwrap();
+        fs::write(root.join("hidden.txt"), b"hidden").unwrap();
+        fs::write(root.join("visible.txt"), b"visible").unwrap();
+
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+        let response = glob_files_with_scope(
+            GlobRequest {
+                pattern: "*.txt".to_string(),
+                path: Some(root.to_string_lossy().into_owned()),
+                filter_mode: Some(FilterMode::Project),
+                sort: Some(SortMode::Path),
+                offset: None,
+                limit: None,
+            },
+            CancellationToken::new(),
+            &scope,
+        );
+        let text = response_path_lines(&response).join("\n");
+        assert!(text.contains("visible.txt"), "{text}");
+        assert!(!text.contains("hidden.txt"), "{text}");
+    }
+
+    #[test]
+    fn restricted_glob_rejects_oversized_ignore_without_partial_matching_or_disclosure() {
+        let fixture = tempfile::tempdir().unwrap();
+        let root = fixture.path().join("root");
+        fs::create_dir(&root).unwrap();
+        let secret = "synthetic-secret-ignore-pattern";
+        let prefix = "hidden.txt\n#";
+        let contents = format!(
+            "{prefix}{}{secret}",
+            "x".repeat(crate::traversal::MAX_IGNORE_CONFIG_BYTES + 1 - prefix.len() - secret.len())
+        );
+        assert_eq!(
+            contents.len(),
+            crate::traversal::MAX_IGNORE_CONFIG_BYTES + 1
+        );
+        fs::write(root.join(".ignore"), contents).unwrap();
+        fs::write(root.join("hidden.txt"), b"hidden").unwrap();
+        fs::write(root.join("visible.txt"), b"visible").unwrap();
+
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+        let response = glob_files_with_scope(
+            GlobRequest {
+                pattern: "*.txt".to_string(),
+                path: Some(root.to_string_lossy().into_owned()),
+                filter_mode: Some(FilterMode::Project),
+                sort: Some(SortMode::Path),
+                offset: None,
+                limit: None,
+            },
+            CancellationToken::new(),
+            &scope,
+        );
+        assert!(response.is_error, "{response:?}");
+        let ToolContent::Text(text) = &response.content[0] else {
+            panic!("expected text error: {response:?}");
+        };
+        assert_eq!(text, "Ignore configuration exceeds maximum size.");
+        for forbidden in [secret, "hidden.txt", "visible.txt"] {
+            assert!(!text.contains(forbidden), "{text}");
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn restricted_glob_lists_unreadable_regular_files_without_opening_them() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let fixture = tempfile::tempdir().unwrap();
+        let path = fixture.path().join("unreadable.txt");
+        fs::write(&path, b"content").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o000)).unwrap();
+        let scope = ReadScope::from_allow_roots(&[fixture.path().to_path_buf()]).unwrap();
+        let request = GlobRequest {
+            pattern: "*.txt".to_string(),
+            path: Some(fixture.path().to_string_lossy().into_owned()),
+            filter_mode: Some(FilterMode::All),
+            sort: Some(SortMode::Modified),
+            offset: None,
+            limit: None,
+        };
+        let restricted = glob_files_with_scope(request.clone(), CancellationToken::new(), &scope);
+        let unrestricted = glob_files_with_scope(
+            request,
+            CancellationToken::new(),
+            &ReadScope::unrestricted(),
+        );
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+        assert_eq!(restricted, unrestricted);
+        assert!(response_path_lines(&restricted)[0].ends_with("unreadable.txt"));
+    }
+
+    #[test]
+    fn restricted_project_walk_matches_walkbuilder_for_anchored_tiered_and_nested_rules() {
+        let fixture = tempfile::tempdir().unwrap();
+        let workspace = fixture.path().join("workspace");
+        let project = workspace.join("project");
+        let nested = project.join("nested");
+        let nested_repo = project.join("nested-repo");
+        fs::create_dir_all(workspace.join(".git/info")).unwrap();
+        fs::create_dir_all(&nested).unwrap();
+        fs::create_dir_all(nested_repo.join(".git")).unwrap();
+
+        fs::write(
+            workspace.join(".gitignore"),
+            "/project/parent-anchored.txt\n/project/nested-repo/outer-must-not-apply.txt\n",
+        )
+        .unwrap();
+        fs::write(
+            workspace.join(".git/info/exclude"),
+            "/project/project-exclude.txt\n",
+        )
+        .unwrap();
+        fs::write(
+            project.join(".gitignore"),
+            "/child-anchored.txt\ntier.txt\nblocked/\n!blocked/keep.txt\n",
+        )
+        .unwrap();
+        fs::write(project.join(".ignore"), "!tier.txt\n").unwrap();
+        fs::write(nested.join(".gitignore"), "/nested-only.txt\n").unwrap();
+        fs::write(nested_repo.join(".gitignore"), "nested-repo-hidden.txt\n").unwrap();
+
+        for path in [
+            project.join("parent-anchored.txt"),
+            project.join("child-anchored.txt"),
+            project.join("project-exclude.txt"),
+            project.join("tier.txt"),
+            project.join("blocked/keep.txt"),
+            nested.join("nested-only.txt"),
+            nested_repo.join("outer-must-not-apply.txt"),
+            nested_repo.join("nested-repo-hidden.txt"),
+            nested_repo.join("visible.txt"),
+        ] {
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).unwrap();
+            }
+            fs::write(path, b"fixture").unwrap();
+        }
+
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&workspace)).unwrap();
+        let request = |filter_mode| GlobRequest {
+            pattern: "**/*".to_string(),
+            path: Some(project.to_string_lossy().into_owned()),
+            filter_mode: Some(filter_mode),
+            sort: Some(SortMode::Path),
+            offset: None,
+            limit: None,
+        };
+        let restricted = glob_files_with_scope(
+            request(FilterMode::Project),
+            CancellationToken::new(),
+            &scope,
+        );
+        let unrestricted = glob_files_with_scope(
+            request(FilterMode::Project),
+            CancellationToken::new(),
+            &ReadScope::unrestricted(),
+        );
+        let all = glob_files_with_scope(request(FilterMode::All), CancellationToken::new(), &scope);
+        assert_eq!(restricted, unrestricted);
+        let project = response_path_lines(&restricted).join("\n");
+        assert!(project.contains("tier.txt"), "{project}");
+        assert!(project.contains("outer-must-not-apply.txt"), "{project}");
+        assert!(project.contains("visible.txt"), "{project}");
+        for hidden in [
+            "parent-anchored.txt",
+            "child-anchored.txt",
+            "project-exclude.txt",
+            "blocked/keep.txt",
+            "nested-only.txt",
+            "nested-repo-hidden.txt",
+        ] {
+            assert!(!project.contains(hidden), "{project}");
+        }
+        let all = response_path_lines(&all).join("\n");
+        assert!(all.contains("blocked/keep.txt"), "{all}");
+        assert!(all.contains("nested-repo-hidden.txt"), "{all}");
+    }
+
+    #[test]
+    fn restricted_project_walk_strips_ignore_bom_like_walkbuilder() {
+        let fixture = tempfile::tempdir().unwrap();
+        let root = fixture.path().join("repo");
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(root.join(".gitignore"), b"\xEF\xBB\xBFhidden.txt\n").unwrap();
+        fs::write(root.join("hidden.txt"), b"hidden").unwrap();
+        fs::write(root.join("visible.txt"), b"visible").unwrap();
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+        let request = GlobRequest {
+            pattern: "*.txt".to_string(),
+            path: Some(root.to_string_lossy().into_owned()),
+            filter_mode: Some(FilterMode::Project),
+            sort: Some(SortMode::Path),
+            offset: None,
+            limit: None,
+        };
+        let restricted = glob_files_with_scope(request.clone(), CancellationToken::new(), &scope);
+        let unrestricted = glob_files_with_scope(
+            request,
+            CancellationToken::new(),
+            &ReadScope::unrestricted(),
+        );
+        assert_eq!(restricted, unrestricted);
+        let text = response_path_lines(&restricted).join("\n");
+        assert!(!text.contains("hidden.txt"), "{text}");
+        assert!(text.contains("visible.txt"), "{text}");
+    }
+
+    #[test]
+    fn restricted_modified_sort_matches_unrestricted() {
+        let fixture = tempfile::tempdir().unwrap();
+        let root = fixture.path().join("root");
+        fs::create_dir(&root).unwrap();
+        let older = root.join("older.txt");
+        let newer = root.join("newer.txt");
+        fs::write(&older, b"old").unwrap();
+        fs::write(&newer, b"new").unwrap();
+        filetime::set_file_mtime(&older, filetime::FileTime::from_unix_time(1, 0)).unwrap();
+        filetime::set_file_mtime(&newer, filetime::FileTime::from_unix_time(2, 0)).unwrap();
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+        let request = GlobRequest {
+            pattern: "*.txt".to_string(),
+            path: Some(root.to_string_lossy().into_owned()),
+            filter_mode: Some(FilterMode::All),
+            sort: Some(SortMode::Modified),
+            offset: None,
+            limit: None,
+        };
+        let restricted = glob_files_with_scope(request.clone(), CancellationToken::new(), &scope);
+        let unrestricted = glob_files_with_scope(
+            request,
+            CancellationToken::new(),
+            &ReadScope::unrestricted(),
+        );
+        assert_eq!(restricted, unrestricted);
+        let lines = response_path_lines(&restricted);
+        assert!(lines[0].ends_with("newer.txt"), "{lines:?}");
+    }
+
+    #[test]
+    fn restricted_walk_is_iterative_and_stops_at_the_candidate_limit() {
+        let fixture = tempfile::tempdir().unwrap();
+        let root = fixture.path().join("root");
+        fs::create_dir(&root).unwrap();
+        let mut deep = root.clone();
+        for _ in 0..256 {
+            deep.push("nested");
+            fs::create_dir(&deep).unwrap();
+        }
+        fs::write(deep.join("leaf.txt"), b"leaf").unwrap();
+        fs::write(root.join("first.txt"), b"first").unwrap();
+        fs::write(root.join("second.txt"), b"second").unwrap();
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+        let request = GlobRequest {
+            pattern: "**/*.txt".to_string(),
+            path: Some(root.to_string_lossy().into_owned()),
+            filter_mode: Some(FilterMode::All),
+            sort: Some(SortMode::Path),
+            offset: None,
+            limit: None,
+        };
+        let restricted = glob_files_with_scope(request.clone(), CancellationToken::new(), &scope);
+        let unrestricted = glob_files_with_scope(
+            request,
+            CancellationToken::new(),
+            &ReadScope::unrestricted(),
+        );
+        assert_eq!(restricted, unrestricted);
+
+        let resolved = crate::path_codec::resolve_search_root_with_scope(
+            Some(&root.to_string_lossy()),
+            RootRequirement::Directory,
+            &scope,
+        )
+        .unwrap();
+        let error = crate::traversal::collect_capability_candidates_filtered(
+            &resolved,
+            None,
+            None,
+            None,
+            crate::traversal::CapabilityCandidateOptions {
+                honor_ignore: false,
+                detail: crate::traversal::CandidateDetail::Path,
+                limit: Some(1),
+                limit_message: "candidate cap reached",
+            },
+        )
+        .unwrap_err();
+        assert_eq!(error, "candidate cap reached");
+    }
+
+    #[test]
+    fn restricted_global_ignore_matches_unrestricted_in_isolated_subprocess() {
+        if env::var_os("FASTCTX_GLOBAL_IGNORE_CHILD").is_some() {
+            let global =
+                std::path::PathBuf::from(env::var_os("FASTCTX_GLOBAL_IGNORE_PATH").unwrap());
+            fs::write(&global, "globally-hidden.txt\n").unwrap();
+            let fixture = tempfile::tempdir().unwrap();
+            let root = fixture.path().join("project");
+            fs::create_dir(&root).unwrap();
+            fs::create_dir(root.join(".git")).unwrap();
+            fs::write(root.join("globally-hidden.txt"), b"hidden").unwrap();
+            fs::write(root.join("visible.txt"), b"visible").unwrap();
+            let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+            let request = |filter_mode| GlobRequest {
+                pattern: "**/*".to_string(),
+                path: Some(root.to_string_lossy().into_owned()),
+                filter_mode: Some(filter_mode),
+                sort: Some(SortMode::Path),
+                offset: None,
+                limit: None,
+            };
+            let project = glob_files_with_scope(
+                request(FilterMode::Project),
+                CancellationToken::new(),
+                &scope,
+            );
+            let unrestricted = glob_files_with_scope(
+                request(FilterMode::Project),
+                CancellationToken::new(),
+                &ReadScope::unrestricted(),
+            );
+            let all =
+                glob_files_with_scope(request(FilterMode::All), CancellationToken::new(), &scope);
+            assert_eq!(project, unrestricted);
+            let ToolContent::Text(project) = &project.content[0] else {
+                panic!("{project:?}")
+            };
+            let ToolContent::Text(all) = &all.content[0] else {
+                panic!("{all:?}")
+            };
+            assert!(!project.contains("globally-hidden.txt"), "{project}");
+            assert!(all.contains("globally-hidden.txt"), "{all}");
+            return;
+        }
+        let fixture = tempfile::tempdir().unwrap();
+        let config = fixture.path().join("gitconfig");
+        let global = fixture.path().join("global-ignore");
+        fs::write(
+            &config,
+            format!("[core]\n\texcludesFile = {}\n", global.display()),
+        )
+        .unwrap();
+        let status = Command::new(env::current_exe().unwrap())
+            .arg("--exact")
+            .arg("glob_tool::tests::restricted_global_ignore_matches_unrestricted_in_isolated_subprocess")
+            .env("FASTCTX_GLOBAL_IGNORE_CHILD", "1")
+            .env("FASTCTX_GLOBAL_IGNORE_PATH", &global)
+            .env("GIT_CONFIG_GLOBAL", &config)
+            .env("HOME", fixture.path())
+            .env("XDG_CONFIG_HOME", fixture.path().join("xdg"))
+            .status()
+            .unwrap();
+        assert!(status.success(), "global-ignore child failed: {status}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn restricted_glob_keeps_stable_file_symlinks_in_configured_roots() {
+        let fixture = tempfile::tempdir().unwrap();
+        let left = fixture.path().join("left");
+        let right = fixture.path().join("right");
+        fs::create_dir(&left).unwrap();
+        fs::create_dir(&right).unwrap();
+        fs::write(left.join("same-target.txt"), b"same").unwrap();
+        fs::write(right.join("cross-target.txt"), b"cross").unwrap();
+        std::os::unix::fs::symlink("same-target.txt", left.join("same-link.txt")).unwrap();
+        std::os::unix::fs::symlink(right.join("cross-target.txt"), left.join("cross-link.txt"))
+            .unwrap();
+        let scope = ReadScope::from_allow_roots(&[left.clone(), right]).unwrap();
+        let request = GlobRequest {
+            pattern: "*.txt".to_string(),
+            path: Some(left.to_string_lossy().into_owned()),
+            filter_mode: Some(FilterMode::All),
+            sort: Some(SortMode::Path),
+            offset: None,
+            limit: None,
+        };
+        let restricted = glob_files_with_scope(request.clone(), CancellationToken::new(), &scope);
+        let unrestricted = glob_files_with_scope(
+            request,
+            CancellationToken::new(),
+            &ReadScope::unrestricted(),
+        );
+        assert_eq!(restricted, unrestricted);
+        let paths = response_path_lines(&restricted);
+        assert!(
+            paths.iter().any(|path| path.ends_with("same-link.txt")),
+            "{paths:?}"
+        );
+        assert!(
+            paths.iter().any(|path| path.ends_with("cross-link.txt")),
+            "{paths:?}"
+        );
+    }
+
     #[cfg(unix)]
     #[test]
     fn scoped_glob_denies_recursive_file_symlink_without_returning_target_path() {
@@ -905,6 +1572,53 @@ mod tests {
             panic!("expected text error");
         };
         assert!(text.starts_with("Permission denied: "), "{text}");
+        assert!(
+            !text.contains(&outside.to_string_lossy().to_string()),
+            "{text}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn restricted_glob_fails_closed_when_candidate_symlink_retargets_after_routing() {
+        let fixture = tempfile::tempdir().unwrap();
+        let root = fixture.path().join("allowed");
+        let outside = fixture.path().join("outside.txt");
+        fs::create_dir(&root).unwrap();
+        fs::File::create(root.join("inside.txt")).unwrap();
+        fs::File::create(&outside).unwrap();
+        let link = root.join("candidate-link.txt");
+        let old_link = root.join("candidate-link.old");
+        std::os::unix::fs::symlink("inside.txt", &link).unwrap();
+        let link_for_hook = link.clone();
+        let old_for_hook = old_link.clone();
+        let outside_for_hook = outside.clone();
+        let _hook = crate::file_snapshot::tests::OriginalOpenObserverGuard::install(Arc::new(
+            move |path| {
+                if path == link_for_hook && link_for_hook.exists() {
+                    fs::rename(&link_for_hook, &old_for_hook).unwrap();
+                    std::os::unix::fs::symlink(&outside_for_hook, &link_for_hook).unwrap();
+                }
+            },
+        ));
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+        let response = glob_files_with_scope(
+            GlobRequest {
+                pattern: "**/*".to_string(),
+                path: Some(root.to_string_lossy().into_owned()),
+                filter_mode: Some(FilterMode::All),
+                sort: Some(SortMode::Path),
+                offset: None,
+                limit: None,
+            },
+            CancellationToken::new(),
+            &scope,
+        );
+        let ToolContent::Text(text) = &response.content[0] else {
+            panic!("expected text response: {response:?}");
+        };
+        assert!(response.is_error || text.contains("inside.txt"), "{text}");
+        assert!(!text.contains("candidate-link.txt"), "{text}");
         assert!(
             !text.contains(&outside.to_string_lossy().to_string()),
             "{text}"

--- a/src/glob_tool.rs
+++ b/src/glob_tool.rs
@@ -7,7 +7,10 @@ use crate::budget::{
 use crate::file_executor::GrepGlobExecutor;
 use crate::model::ToolResponse;
 use crate::operation::{OpError, OperationCtx, RequestWorkGuard};
-use crate::path_codec::{PathRecord, ResolvedRoot, RootRequirement, resolve_search_root};
+use crate::path_codec::{
+    PathRecord, ResolvedRoot, RootRequirement, resolve_search_root_with_scope,
+};
+use crate::paths::ReadScope;
 use crate::render_plan::{LineRenderGraph, RenderPlanError};
 use crate::traversal::{TraversalFailure, TraversalLimit, collect_walk_batched};
 use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
@@ -83,19 +86,29 @@ struct GlobCollectionProbe {
 /// rendering, and token verification. A cancelled operation returns an error
 /// response and never exposes a partial success body.
 pub fn glob_files(request: GlobRequest, cancellation: CancellationToken) -> ToolResponse {
+    glob_files_with_scope(request, cancellation, &ReadScope::unrestricted())
+}
+
+pub(crate) fn glob_files_with_scope(
+    request: GlobRequest,
+    cancellation: CancellationToken,
+    scope: &ReadScope,
+) -> ToolResponse {
     let (mut guard, operation) = RequestWorkGuard::new(
         rmcp::model::RequestId::String(Arc::from("direct-glob")),
         cancellation,
     );
-    let response = glob_files_with_execution(request, operation, GrepGlobExecutor::shared());
+    let response =
+        glob_files_with_execution_scoped(request, operation, GrepGlobExecutor::shared(), scope);
     guard.disarm();
     response
 }
 
-fn glob_files_with_execution(
+fn glob_files_with_execution_scoped(
     request: GlobRequest,
     operation: OperationCtx,
     executor: Arc<GrepGlobExecutor>,
+    scope: &ReadScope,
 ) -> ToolResponse {
     let adapter = ErrorBudgetAdapter::new(
         error_budget_hint(GLOB_TOKEN_BUDGET_ENV),
@@ -113,6 +126,7 @@ fn glob_files_with_execution(
         &executor,
         #[cfg(test)]
         None,
+        scope,
     ))
 }
 
@@ -123,11 +137,16 @@ fn glob_files_with_execution_unadapted(
     operation: &OperationCtx,
     executor: &Arc<GrepGlobExecutor>,
     #[cfg(test)] collection_probe: Option<&GlobCollectionProbe>,
+    scope: &ReadScope,
 ) -> ToolResponse {
     if operation.check().is_err() {
         return ToolResponse::error("Request cancelled.");
     }
-    let root = match resolve_search_root(request.path.as_deref(), RootRequirement::Directory) {
+    let root = match resolve_search_root_with_scope(
+        request.path.as_deref(),
+        RootRequirement::Directory,
+        scope,
+    ) {
         Ok(root) => root,
         Err(message) => return ToolResponse::error(message),
     };
@@ -180,11 +199,12 @@ fn glob_files_with_execution_unadapted(
 pub(crate) fn glob_files_cancellable(
     operation: OperationCtx,
     executor: Arc<GrepGlobExecutor>,
+    scope: ReadScope,
     request: GlobRequest,
 ) -> Result<ToolResponse, OpError> {
     let work = operation.inline_work();
     work.check_inline()?;
-    let response = glob_files_with_execution(request, operation.clone(), executor);
+    let response = glob_files_with_execution_scoped(request, operation.clone(), executor, &scope);
     work.check_inline()?;
     Ok(response)
 }
@@ -311,6 +331,12 @@ fn evaluate_match(
         .file_type()
         .is_some_and(|file_type| file_type.is_symlink())
     {
+        if let Err(message) = root
+            .scope
+            .authorize_with_formatter(path, crate::path_codec::display_path)
+        {
+            return Err(TraversalFailure::from_other(path, message));
+        }
         // Symlinks keep the follow-and-check semantics (broken links skip).
         #[cfg(test)]
         record_metadata_lookup(collection_probe);
@@ -534,11 +560,13 @@ mod tests {
     use super::{
         FilterMode, GlobCollectionProbe, GlobRequest, MatchEntry, SortMode, build_matcher,
         collect_matches, ensure_result_capacity, format_matches,
-        glob_files_with_execution_unadapted,
+        glob_files_with_execution_unadapted, glob_files_with_scope,
     };
     use crate::file_executor::{GrepGlobExecutor, LedgerSnapshot};
     use crate::operation::RequestWorkGuard;
+    use crate::path_codec::display_path as search_display_path;
     use crate::path_codec::{PathRecord, RootRequirement, resolve_search_root};
+    use crate::paths::ReadScope;
     use crate::render_plan::RenderPlanMetrics;
     use crate::{ToolContent, ToolResponse};
     use rmcp::model::RequestId;
@@ -571,6 +599,7 @@ mod tests {
             &operation,
             &executor,
             None,
+            &ReadScope::unrestricted(),
         );
         guard.disarm();
         executor.wait_for_test_quiescence();
@@ -818,5 +847,145 @@ mod tests {
             assert_released_once(burst);
             assert_released_once(tickets);
         }
+    }
+
+    #[test]
+    fn scoped_glob_denies_explicit_outside_root() {
+        let fixture = tempfile::tempdir().unwrap();
+        let root = fixture.path().join("work");
+        let outside = fixture.path().join("outside");
+        fs::create_dir(&root).unwrap();
+        fs::create_dir(&outside).unwrap();
+        fs::File::create(outside.join("outside.txt")).unwrap();
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+        let response = glob_files_with_scope(
+            GlobRequest {
+                pattern: "**/*".to_string(),
+                path: Some(outside.to_string_lossy().into_owned()),
+                filter_mode: Some(FilterMode::All),
+                sort: Some(SortMode::Path),
+                offset: None,
+                limit: None,
+            },
+            CancellationToken::new(),
+            &scope,
+        );
+        assert!(response.is_error, "{response:?}");
+        let ToolContent::Text(text) = &response.content[0] else {
+            panic!("expected text error");
+        };
+        assert!(text.starts_with("Permission denied: "), "{text}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn scoped_glob_denies_recursive_file_symlink_without_returning_target_path() {
+        let fixture = tempfile::tempdir().unwrap();
+        let root = fixture.path().join("allowed");
+        let outside = fixture.path().join("outside.txt");
+        fs::create_dir(&root).unwrap();
+        fs::File::create(&outside).unwrap();
+        let link = root.join("outside-link.txt");
+        std::os::unix::fs::symlink(&outside, &link).unwrap();
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+        let response = glob_files_with_scope(
+            GlobRequest {
+                pattern: "**/*".to_string(),
+                path: Some(root.to_string_lossy().into_owned()),
+                filter_mode: Some(FilterMode::All),
+                sort: Some(SortMode::Path),
+                offset: None,
+                limit: None,
+            },
+            CancellationToken::new(),
+            &scope,
+        );
+        assert!(response.is_error, "{response:?}");
+        let ToolContent::Text(text) = &response.content[0] else {
+            panic!("expected text error");
+        };
+        assert!(text.starts_with("Permission denied: "), "{text}");
+        assert!(
+            !text.contains(&outside.to_string_lossy().to_string()),
+            "{text}"
+        );
+    }
+
+    #[test]
+    fn restricted_relative_glob_request_has_no_cwd_diagnostics() {
+        let fixture = tempfile::tempdir().unwrap();
+        let scope = ReadScope::from_allow_roots(&[fixture.path().to_path_buf()]).unwrap();
+        let response = glob_files_with_scope(
+            GlobRequest {
+                pattern: "*".to_string(),
+                path: Some("relative".to_string()),
+                filter_mode: Some(FilterMode::All),
+                sort: Some(SortMode::Path),
+                offset: None,
+                limit: None,
+            },
+            CancellationToken::new(),
+            &scope,
+        );
+        let ToolContent::Text(text) = &response.content[0] else {
+            panic!("expected text error");
+        };
+        assert_eq!(text, "Path must be absolute: relative");
+    }
+
+    #[test]
+    fn scoped_glob_denial_uses_line_safe_encoded_path_display() {
+        let fixture = tempfile::tempdir().unwrap();
+        let root = fixture.path().join("allowed");
+        let outside = fixture.path().join("outside\nsecret.txt");
+        fs::create_dir(&root).unwrap();
+        fs::File::create(&outside).unwrap();
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+        let response = glob_files_with_scope(
+            GlobRequest {
+                pattern: "*".to_string(),
+                path: Some(search_display_path(&outside)),
+                filter_mode: Some(FilterMode::All),
+                sort: Some(SortMode::Path),
+                offset: None,
+                limit: None,
+            },
+            CancellationToken::new(),
+            &scope,
+        );
+        let ToolContent::Text(text) = &response.content[0] else {
+            panic!("expected text error");
+        };
+        assert!(text.contains("~fastctx~b"), "{text}");
+        assert!(!text.contains('\n'), "{text:?}");
+        assert!(!text.contains("outside\nsecret"), "{text:?}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn scoped_glob_symlink_resolution_errors_use_line_safe_encoded_paths() {
+        let fixture = tempfile::tempdir().unwrap();
+        let root = fixture.path().join("allowed");
+        fs::create_dir(&root).unwrap();
+        let link = root.join("loop\nname");
+        std::os::unix::fs::symlink("loop\nname", &link).unwrap();
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+        let response = glob_files_with_scope(
+            GlobRequest {
+                pattern: "**/*".to_string(),
+                path: Some(root.to_string_lossy().into_owned()),
+                filter_mode: Some(FilterMode::All),
+                sort: Some(SortMode::Path),
+                offset: None,
+                limit: None,
+            },
+            CancellationToken::new(),
+            &scope,
+        );
+        let ToolContent::Text(text) = &response.content[0] else {
+            panic!("expected text error");
+        };
+        assert!(text.contains("~fastctx~b"), "{text}");
+        assert!(!text.contains('\n'), "{text:?}");
     }
 }

--- a/src/glob_tool.rs
+++ b/src/glob_tool.rs
@@ -252,12 +252,10 @@ fn collect_matches(
                 limit_message: TOO_MANY_MATCHES_ERROR,
             },
         )?;
-        let mut matches = candidates
+        return Ok(candidates
             .into_iter()
             .map(|path| MatchEntry { path })
-            .collect::<Vec<_>>();
-        matches.sort_by(|left, right| compare_match_entries(sort, left, right));
-        return Ok(matches);
+            .collect());
     }
     let mut builder = WalkBuilder::new(&root.native);
     match filter_mode {
@@ -355,12 +353,6 @@ fn evaluate_match(
         .file_type()
         .is_some_and(|file_type| file_type.is_symlink())
     {
-        if let Err(message) = root
-            .scope
-            .authorize_with_formatter(path, crate::path_codec::display_path)
-        {
-            return Err(TraversalFailure::from_other(path, message));
-        }
         // Symlinks keep the follow-and-check semantics (broken links skip).
         #[cfg(test)]
         record_metadata_lookup(collection_probe);
@@ -657,6 +649,22 @@ mod tests {
         }
     }
 
+    fn restricted_project_glob(root: &Path) -> ToolResponse {
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root.to_path_buf())).unwrap();
+        glob_files_with_scope(
+            GlobRequest {
+                pattern: "*.txt".to_string(),
+                path: Some(root.to_string_lossy().into_owned()),
+                filter_mode: Some(FilterMode::Project),
+                sort: Some(SortMode::Path),
+                offset: None,
+                limit: None,
+            },
+            CancellationToken::new(),
+            &scope,
+        )
+    }
+
     fn safe_fixture_display(path: &Path) -> String {
         let native = path.to_string_lossy();
         #[cfg(windows)]
@@ -876,264 +884,74 @@ mod tests {
     }
 
     #[test]
-    fn scoped_glob_denies_explicit_outside_root() {
-        let fixture = tempfile::tempdir().unwrap();
-        let root = fixture.path().join("work");
-        let outside = fixture.path().join("outside");
-        fs::create_dir(&root).unwrap();
-        fs::create_dir(&outside).unwrap();
-        fs::File::create(outside.join("outside.txt")).unwrap();
-        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
-        let response = glob_files_with_scope(
-            GlobRequest {
-                pattern: "**/*".to_string(),
-                path: Some(outside.to_string_lossy().into_owned()),
-                filter_mode: Some(FilterMode::All),
-                sort: Some(SortMode::Path),
-                offset: None,
-                limit: None,
-            },
-            CancellationToken::new(),
-            &scope,
-        );
-        assert!(response.is_error, "{response:?}");
-        let ToolContent::Text(text) = &response.content[0] else {
-            panic!("expected text error");
-        };
-        assert!(text.starts_with("Permission denied: "), "{text}");
-    }
-
-    #[test]
-    fn restricted_glob_preserves_nested_ignore_and_filter_mode_semantics() {
-        let fixture = tempfile::tempdir().unwrap();
-        let workspace = fixture.path().join("workspace");
-        let root = workspace.join("project");
-        let nested = root.join("nested");
-        fs::create_dir_all(&nested).unwrap();
-        fs::write(workspace.join(".gitignore"), "parent-git.txt\n").unwrap();
-        fs::write(workspace.join(".ignore"), "parent-ignore.txt\n").unwrap();
-        fs::create_dir_all(workspace.join(".git/info")).unwrap();
-        fs::write(workspace.join(".git/info/exclude"), "excluded.txt\n").unwrap();
-        fs::write(root.join(".gitignore"), "ignored-git.txt\nnested/*.tmp\n").unwrap();
-        fs::write(root.join(".ignore"), "ignored-ignore.txt\n").unwrap();
-        fs::write(nested.join(".gitignore"), "*.tmp\n!keep.tmp\n").unwrap();
-        fs::write(root.join("visible.txt"), b"visible").unwrap();
-        fs::write(root.join(".hidden.txt"), b"hidden").unwrap();
-        fs::write(root.join("ignored-git.txt"), b"git").unwrap();
-        fs::write(root.join("ignored-ignore.txt"), b"ignore").unwrap();
-        fs::write(root.join("parent-git.txt"), b"parent").unwrap();
-        fs::write(root.join("parent-ignore.txt"), b"parent").unwrap();
-        fs::write(root.join("excluded.txt"), b"excluded").unwrap();
-        fs::write(nested.join("keep.txt"), b"keep").unwrap();
-        fs::write(nested.join("drop.tmp"), b"drop").unwrap();
-        fs::write(nested.join("keep.tmp"), b"keep").unwrap();
-        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&workspace)).unwrap();
-        let request = |filter_mode| GlobRequest {
-            pattern: "**/*".to_string(),
-            path: Some(root.to_string_lossy().into_owned()),
-            filter_mode: Some(filter_mode),
-            sort: Some(SortMode::Path),
-            offset: None,
-            limit: None,
-        };
-        let project = glob_files_with_scope(
-            request(FilterMode::Project),
-            CancellationToken::new(),
-            &scope,
-        );
-        let unrestricted = glob_files_with_scope(
-            request(FilterMode::Project),
-            CancellationToken::new(),
-            &ReadScope::unrestricted(),
-        );
-        let all = glob_files_with_scope(request(FilterMode::All), CancellationToken::new(), &scope);
-        let ToolContent::Text(project_text) = &project.content[0] else {
-            panic!("expected project response: {project:?}");
-        };
-        let ToolContent::Text(all_text) = &all.content[0] else {
-            panic!("expected all response: {all:?}");
-        };
-        let ToolContent::Text(unrestricted_text) = &unrestricted.content[0] else {
-            panic!("expected unrestricted response: {unrestricted:?}");
-        };
-        assert_eq!(project_text, unrestricted_text);
-        assert!(project_text.contains("visible.txt"), "{project_text}");
-        assert!(project_text.contains(".hidden.txt"), "{project_text}");
-        assert!(project_text.contains("keep.txt"), "{project_text}");
-        assert!(project_text.contains("keep.tmp"), "{project_text}");
-        assert!(!project_text.contains("ignored-git.txt"), "{project_text}");
-        assert!(
-            !project_text.contains("ignored-ignore.txt"),
-            "{project_text}"
-        );
-        assert!(!project_text.contains("drop.tmp"), "{project_text}");
-        for name in ["parent-git.txt", "parent-ignore.txt", "excluded.txt"] {
-            assert!(!project_text.contains(name), "{project_text}");
-        }
-        for name in [
-            "visible.txt",
-            ".hidden.txt",
-            "ignored-git.txt",
-            "ignored-ignore.txt",
-            "keep.txt",
-            "drop.tmp",
-            "keep.tmp",
-            "parent-git.txt",
-            "parent-ignore.txt",
-            "excluded.txt",
+    fn restricted_project_walk_reads_worktree_excludes_from_commondir_or_gitdir() {
+        for (name, gitdir_relative, commondir, exclude_relative) in [
+            (
+                "relative commondir",
+                "../common/.git/worktrees/checked-out",
+                Some("../.."),
+                "../common/.git/info/exclude",
+            ),
+            (
+                "gitdir fallback",
+                "../gitdir",
+                None,
+                "../gitdir/info/exclude",
+            ),
         ] {
-            assert!(all_text.contains(name), "{all_text}");
+            let fixture = tempfile::tempdir().unwrap();
+            let root = fixture.path().join("worktree");
+            let gitdir = root.join(gitdir_relative);
+            let exclude = root.join(exclude_relative);
+            fs::create_dir(&root).unwrap();
+            fs::create_dir_all(&gitdir).unwrap();
+            fs::create_dir_all(exclude.parent().unwrap()).unwrap();
+            fs::write(root.join(".git"), format!("gitdir: {gitdir_relative}\n")).unwrap();
+            if let Some(commondir) = commondir {
+                fs::write(gitdir.join("commondir"), format!("{commondir}\n")).unwrap();
+            }
+            fs::write(exclude, "excluded.txt\n").unwrap();
+            fs::write(root.join("excluded.txt"), b"excluded").unwrap();
+            fs::write(root.join("visible.txt"), b"visible").unwrap();
+
+            let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+            let restricted = glob_files_with_scope(
+                GlobRequest {
+                    pattern: "*.txt".to_string(),
+                    path: Some(root.to_string_lossy().into_owned()),
+                    filter_mode: Some(FilterMode::Project),
+                    sort: Some(SortMode::Path),
+                    offset: None,
+                    limit: None,
+                },
+                CancellationToken::new(),
+                &scope,
+            );
+            let text = response_path_lines(&restricted).join("\n");
+            assert!(text.contains("visible.txt"), "{name}: {text}");
+            assert!(!text.contains("excluded.txt"), "{name}: {text}");
         }
     }
 
     #[test]
-    fn restricted_project_walk_reads_parent_rules_when_nested_allow_root_wins() {
-        let fixture = tempfile::tempdir().unwrap();
-        let repository = fixture.path().join("repository");
-        let root = repository.join("subdir");
-        fs::create_dir_all(repository.join(".git/info")).unwrap();
-        fs::create_dir(&root).unwrap();
-        fs::write(repository.join(".ignore"), "/subdir/parent-ignore.txt\n").unwrap();
-        fs::write(
-            repository.join(".gitignore"),
-            "/subdir/parent-gitignore.txt\n",
-        )
-        .unwrap();
-        fs::write(
-            repository.join(".git/info/exclude"),
-            "subdir/parent-exclude.txt\n",
-        )
-        .unwrap();
-        for name in [
-            "parent-ignore.txt",
-            "parent-gitignore.txt",
-            "parent-exclude.txt",
-            "visible.txt",
-        ] {
-            fs::write(root.join(name), b"fixture").unwrap();
-        }
-
-        // The longest matching configured root is `subdir`, so every rule is
-        // outside its capability and must be loaded as filtering-only config.
-        let scope = ReadScope::from_allow_roots(&[repository, root.clone()]).unwrap();
-        let request = GlobRequest {
-            pattern: "*.txt".to_string(),
-            path: Some(root.to_string_lossy().into_owned()),
-            filter_mode: Some(FilterMode::Project),
-            sort: Some(SortMode::Path),
-            offset: None,
-            limit: None,
-        };
-        let restricted = glob_files_with_scope(request.clone(), CancellationToken::new(), &scope);
-        let unrestricted = glob_files_with_scope(
-            request,
-            CancellationToken::new(),
-            &ReadScope::unrestricted(),
-        );
-        assert_eq!(restricted, unrestricted);
-        let text = response_path_lines(&restricted).join("\n");
-        assert!(text.contains("visible.txt"), "{text}");
-        for hidden in [
-            "parent-ignore.txt",
-            "parent-gitignore.txt",
-            "parent-exclude.txt",
-        ] {
-            assert!(!text.contains(hidden), "{text}");
-        }
-    }
-
-    #[test]
-    fn restricted_project_walk_reads_relative_gitdir_commondir_exclude_outside_root() {
-        let fixture = tempfile::tempdir().unwrap();
-        let common = fixture.path().join("common");
-        let gitdir = common.join(".git/worktrees/checked-out");
-        let root = fixture.path().join("worktree");
-        fs::create_dir_all(common.join(".git/info")).unwrap();
-        fs::create_dir_all(&gitdir).unwrap();
-        fs::create_dir(&root).unwrap();
-        fs::write(
-            root.join(".git"),
-            "gitdir: ../common/.git/worktrees/checked-out\n",
-        )
-        .unwrap();
-        fs::write(gitdir.join("commondir"), "../..\n").unwrap();
-        fs::write(common.join(".git/info/exclude"), "excluded.txt\n").unwrap();
-        fs::write(root.join("excluded.txt"), b"excluded").unwrap();
-        fs::write(root.join("visible.txt"), b"visible").unwrap();
-
-        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
-        let request = GlobRequest {
-            pattern: "*.txt".to_string(),
-            path: Some(root.to_string_lossy().into_owned()),
-            filter_mode: Some(FilterMode::Project),
-            sort: Some(SortMode::Path),
-            offset: None,
-            limit: None,
-        };
-        let restricted = glob_files_with_scope(request, CancellationToken::new(), &scope);
-        let text = response_path_lines(&restricted).join("\n");
-        assert!(text.contains("visible.txt"), "{text}");
-        assert!(!text.contains("excluded.txt"), "{text}");
-    }
-
-    #[test]
-    fn restricted_project_walk_uses_gitdir_exclude_when_commondir_is_absent() {
-        let fixture = tempfile::tempdir().unwrap();
-        let gitdir = fixture.path().join("gitdir");
-        let root = fixture.path().join("worktree");
-        fs::create_dir_all(gitdir.join("info")).unwrap();
-        fs::create_dir(&root).unwrap();
-        fs::write(root.join(".git"), "gitdir: ../gitdir\n").unwrap();
-        fs::write(gitdir.join("info/exclude"), "excluded.txt\n").unwrap();
-        fs::write(root.join("excluded.txt"), b"excluded").unwrap();
-        fs::write(root.join("visible.txt"), b"visible").unwrap();
-
-        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
-        let request = GlobRequest {
-            pattern: "*.txt".to_string(),
-            path: Some(root.to_string_lossy().into_owned()),
-            filter_mode: Some(FilterMode::Project),
-            sort: Some(SortMode::Path),
-            offset: None,
-            limit: None,
-        };
-        let restricted = glob_files_with_scope(request, CancellationToken::new(), &scope);
-        let text = response_path_lines(&restricted).join("\n");
-        assert!(text.contains("visible.txt"), "{text}");
-        assert!(!text.contains("excluded.txt"), "{text}");
-    }
-
-    #[test]
-    fn malformed_parent_ignore_never_exposes_its_pattern() {
+    fn malformed_parent_ignore_is_not_disclosed_and_later_rule_still_filters() {
         let fixture = tempfile::tempdir().unwrap();
         let parent = fixture.path().join("parent");
         let root = parent.join("root");
-        fs::create_dir(&parent).unwrap();
-        fs::create_dir(&root).unwrap();
+        fs::create_dir_all(&root).unwrap();
         let secret = "synthetic-secret-ignore-pattern";
         fs::write(parent.join(".ignore"), format!("[{secret}\nhidden.txt\n")).unwrap();
         fs::write(root.join("hidden.txt"), b"hidden").unwrap();
         fs::write(root.join("visible.txt"), b"visible").unwrap();
 
-        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
-        let response = glob_files_with_scope(
-            GlobRequest {
-                pattern: "*.txt".to_string(),
-                path: Some(root.to_string_lossy().into_owned()),
-                filter_mode: Some(FilterMode::Project),
-                sort: Some(SortMode::Path),
-                offset: None,
-                limit: None,
-            },
-            CancellationToken::new(),
-            &scope,
-        );
+        let response = restricted_project_glob(&root);
         let ToolContent::Text(text) = &response.content[0] else {
             panic!("expected text response: {response:?}");
         };
         assert!(!text.contains(secret), "{text}");
-        assert!(text.contains("visible.txt"), "{text}");
-        assert!(!text.contains("hidden.txt"), "{text}");
+        let paths = response_path_lines(&response);
+        assert_eq!(paths.len(), 1, "{paths:?}");
+        assert!(paths[0].ends_with("visible.txt"), "{paths:?}");
     }
 
     #[test]
@@ -1151,22 +969,9 @@ mod tests {
         fs::write(root.join("hidden.txt"), b"hidden").unwrap();
         fs::write(root.join("visible.txt"), b"visible").unwrap();
 
-        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
-        let response = glob_files_with_scope(
-            GlobRequest {
-                pattern: "*.txt".to_string(),
-                path: Some(root.to_string_lossy().into_owned()),
-                filter_mode: Some(FilterMode::Project),
-                sort: Some(SortMode::Path),
-                offset: None,
-                limit: None,
-            },
-            CancellationToken::new(),
-            &scope,
-        );
-        let text = response_path_lines(&response).join("\n");
-        assert!(text.contains("visible.txt"), "{text}");
-        assert!(!text.contains("hidden.txt"), "{text}");
+        let paths = response_path_lines(&restricted_project_glob(&root));
+        assert_eq!(paths.len(), 1, "{paths:?}");
+        assert!(paths[0].ends_with("visible.txt"), "{paths:?}");
     }
 
     #[test]
@@ -1188,19 +993,7 @@ mod tests {
         fs::write(root.join("hidden.txt"), b"hidden").unwrap();
         fs::write(root.join("visible.txt"), b"visible").unwrap();
 
-        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
-        let response = glob_files_with_scope(
-            GlobRequest {
-                pattern: "*.txt".to_string(),
-                path: Some(root.to_string_lossy().into_owned()),
-                filter_mode: Some(FilterMode::Project),
-                sort: Some(SortMode::Path),
-                offset: None,
-                limit: None,
-            },
-            CancellationToken::new(),
-            &scope,
-        );
+        let response = restricted_project_glob(&root);
         assert!(response.is_error, "{response:?}");
         let ToolContent::Text(text) = &response.content[0] else {
             panic!("expected text error: {response:?}");
@@ -1241,7 +1034,7 @@ mod tests {
     }
 
     #[test]
-    fn restricted_project_walk_matches_walkbuilder_for_anchored_tiered_and_nested_rules() {
+    fn restricted_project_walk_matches_walkbuilder_matrix() {
         let fixture = tempfile::tempdir().unwrap();
         let workspace = fixture.path().join("workspace");
         let project = workspace.join("project");
@@ -1253,9 +1046,10 @@ mod tests {
 
         fs::write(
             workspace.join(".gitignore"),
-            "/project/parent-anchored.txt\n/project/nested-repo/outer-must-not-apply.txt\n",
+            b"\xEF\xBB\xBF/project/parent-anchored.txt\n/project/nested-repo/outer-must-not-apply.txt\n",
         )
         .unwrap();
+        fs::write(workspace.join(".ignore"), "/project/parent-ignore.txt\n").unwrap();
         fs::write(
             workspace.join(".git/info/exclude"),
             "/project/project-exclude.txt\n",
@@ -1274,7 +1068,9 @@ mod tests {
             project.join("parent-anchored.txt"),
             project.join("child-anchored.txt"),
             project.join("project-exclude.txt"),
+            project.join("parent-ignore.txt"),
             project.join("tier.txt"),
+            project.join(".hidden.txt"),
             project.join("blocked/keep.txt"),
             nested.join("nested-only.txt"),
             nested_repo.join("outer-must-not-apply.txt"),
@@ -1287,7 +1083,6 @@ mod tests {
             fs::write(path, b"fixture").unwrap();
         }
 
-        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&workspace)).unwrap();
         let request = |filter_mode| GlobRequest {
             pattern: "**/*".to_string(),
             path: Some(project.to_string_lossy().into_owned()),
@@ -1296,64 +1091,49 @@ mod tests {
             offset: None,
             limit: None,
         };
-        let restricted = glob_files_with_scope(
+        for allow_roots in [
+            vec![workspace.clone()],
+            vec![workspace.clone(), project.clone()],
+        ] {
+            let scope = ReadScope::from_allow_roots(&allow_roots).unwrap();
+            for filter_mode in [FilterMode::Project, FilterMode::All] {
+                let restricted =
+                    glob_files_with_scope(request(filter_mode), CancellationToken::new(), &scope);
+                let unrestricted = glob_files_with_scope(
+                    request(filter_mode),
+                    CancellationToken::new(),
+                    &ReadScope::unrestricted(),
+                );
+                assert_eq!(restricted, unrestricted, "{filter_mode:?}, {allow_roots:?}");
+            }
+        }
+
+        let scope = ReadScope::from_allow_roots(&[workspace, project.clone()]).unwrap();
+        let project_result = glob_files_with_scope(
             request(FilterMode::Project),
             CancellationToken::new(),
             &scope,
         );
-        let unrestricted = glob_files_with_scope(
-            request(FilterMode::Project),
-            CancellationToken::new(),
-            &ReadScope::unrestricted(),
-        );
-        let all = glob_files_with_scope(request(FilterMode::All), CancellationToken::new(), &scope);
-        assert_eq!(restricted, unrestricted);
-        let project = response_path_lines(&restricted).join("\n");
-        assert!(project.contains("tier.txt"), "{project}");
-        assert!(project.contains("outer-must-not-apply.txt"), "{project}");
-        assert!(project.contains("visible.txt"), "{project}");
+        let project_text = response_path_lines(&project_result).join("\n");
+        for visible in [
+            "tier.txt",
+            "outer-must-not-apply.txt",
+            "visible.txt",
+            ".hidden.txt",
+        ] {
+            assert!(project_text.contains(visible), "{project_text}");
+        }
         for hidden in [
             "parent-anchored.txt",
+            "parent-ignore.txt",
             "child-anchored.txt",
             "project-exclude.txt",
             "blocked/keep.txt",
             "nested-only.txt",
             "nested-repo-hidden.txt",
         ] {
-            assert!(!project.contains(hidden), "{project}");
+            assert!(!project_text.contains(hidden), "{project_text}");
         }
-        let all = response_path_lines(&all).join("\n");
-        assert!(all.contains("blocked/keep.txt"), "{all}");
-        assert!(all.contains("nested-repo-hidden.txt"), "{all}");
-    }
-
-    #[test]
-    fn restricted_project_walk_strips_ignore_bom_like_walkbuilder() {
-        let fixture = tempfile::tempdir().unwrap();
-        let root = fixture.path().join("repo");
-        fs::create_dir_all(root.join(".git")).unwrap();
-        fs::write(root.join(".gitignore"), b"\xEF\xBB\xBFhidden.txt\n").unwrap();
-        fs::write(root.join("hidden.txt"), b"hidden").unwrap();
-        fs::write(root.join("visible.txt"), b"visible").unwrap();
-        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
-        let request = GlobRequest {
-            pattern: "*.txt".to_string(),
-            path: Some(root.to_string_lossy().into_owned()),
-            filter_mode: Some(FilterMode::Project),
-            sort: Some(SortMode::Path),
-            offset: None,
-            limit: None,
-        };
-        let restricted = glob_files_with_scope(request.clone(), CancellationToken::new(), &scope);
-        let unrestricted = glob_files_with_scope(
-            request,
-            CancellationToken::new(),
-            &ReadScope::unrestricted(),
-        );
-        assert_eq!(restricted, unrestricted);
-        let text = response_path_lines(&restricted).join("\n");
-        assert!(!text.contains("hidden.txt"), "{text}");
-        assert!(text.contains("visible.txt"), "{text}");
     }
 
     #[test]
@@ -1626,29 +1406,7 @@ mod tests {
     }
 
     #[test]
-    fn restricted_relative_glob_request_has_no_cwd_diagnostics() {
-        let fixture = tempfile::tempdir().unwrap();
-        let scope = ReadScope::from_allow_roots(&[fixture.path().to_path_buf()]).unwrap();
-        let response = glob_files_with_scope(
-            GlobRequest {
-                pattern: "*".to_string(),
-                path: Some("relative".to_string()),
-                filter_mode: Some(FilterMode::All),
-                sort: Some(SortMode::Path),
-                offset: None,
-                limit: None,
-            },
-            CancellationToken::new(),
-            &scope,
-        );
-        let ToolContent::Text(text) = &response.content[0] else {
-            panic!("expected text error");
-        };
-        assert_eq!(text, "Path must be absolute: relative");
-    }
-
-    #[test]
-    fn scoped_glob_denial_uses_line_safe_encoded_path_display() {
+    fn scoped_glob_path_denial_is_line_safe_and_does_not_leak_raw_path() {
         let fixture = tempfile::tempdir().unwrap();
         let root = fixture.path().join("allowed");
         let outside = fixture.path().join("outside\nsecret.txt");
@@ -1670,36 +1428,10 @@ mod tests {
         let ToolContent::Text(text) = &response.content[0] else {
             panic!("expected text error");
         };
+        assert!(response.is_error, "{response:?}");
+        assert!(text.starts_with("Permission denied: "), "{text}");
         assert!(text.contains("~fastctx~b"), "{text}");
         assert!(!text.contains('\n'), "{text:?}");
         assert!(!text.contains("outside\nsecret"), "{text:?}");
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn scoped_glob_symlink_resolution_errors_use_line_safe_encoded_paths() {
-        let fixture = tempfile::tempdir().unwrap();
-        let root = fixture.path().join("allowed");
-        fs::create_dir(&root).unwrap();
-        let link = root.join("loop\nname");
-        std::os::unix::fs::symlink("loop\nname", &link).unwrap();
-        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
-        let response = glob_files_with_scope(
-            GlobRequest {
-                pattern: "**/*".to_string(),
-                path: Some(root.to_string_lossy().into_owned()),
-                filter_mode: Some(FilterMode::All),
-                sort: Some(SortMode::Path),
-                offset: None,
-                limit: None,
-            },
-            CancellationToken::new(),
-            &scope,
-        );
-        let ToolContent::Text(text) = &response.content[0] else {
-            panic!("expected text error");
-        };
-        assert!(text.contains("~fastctx~b"), "{text}");
-        assert!(!text.contains('\n'), "{text:?}");
     }
 }

--- a/src/grep_tool.rs
+++ b/src/grep_tool.rs
@@ -9,7 +9,9 @@ use crate::encoding::{
     canonical_encoding_label, validate_snapshot_encoding,
 };
 use crate::file_executor::GrepGlobExecutor;
-use crate::file_snapshot::{CaptureDisposition, CaptureFailure, capture_classify};
+use crate::file_snapshot::{
+    CaptureDisposition, CaptureFailure, capture_classify, capture_classify_open_file,
+};
 use crate::grep_sink::{
     CapturedLine, ContentEntry, ContentSpec, FileResult, GrepSearchPlan, GrepSinkError,
     LineMatchSpan, PlanSink,
@@ -20,7 +22,8 @@ use crate::operation::{
 };
 use crate::ordered_window::{OrderedError, for_each_ordered};
 use crate::path_codec::{
-    PathRecord as Candidate, RootRequirement, io_error_message, resolve_search_root_with_scope,
+    PathRecord as Candidate, RootRequirement, display_path as search_display_path,
+    io_error_message, resolve_search_root_with_scope,
 };
 use crate::paths::ReadScope;
 use crate::render_plan::{
@@ -578,6 +581,7 @@ fn grep_files_with_budget_source_and_execution_unadapted(
         let mut failure: Option<ToolResponse> = None;
         let worker_matcher = Arc::clone(&matcher);
         let worker_encoding = search_encoding.clone();
+        let worker_scope = scope.clone();
         let panic_candidates = Arc::clone(&candidates);
         let ordered = for_each_ordered(
             Arc::clone(&candidates),
@@ -590,6 +594,7 @@ fn grep_files_with_budget_source_and_execution_unadapted(
                     plan,
                     multiline,
                     &worker_encoding,
+                    &worker_scope,
                     work,
                 )
             },
@@ -698,6 +703,7 @@ fn grep_files_with_budget_source_and_execution_unadapted(
     let mut failure: Option<String> = None;
     let worker_matcher = Arc::clone(&matcher);
     let worker_encoding = search_encoding.clone();
+    let worker_scope = scope.clone();
     let panic_candidates = Arc::clone(&candidates);
     let ordered = for_each_ordered(
         Arc::clone(&candidates),
@@ -710,6 +716,7 @@ fn grep_files_with_budget_source_and_execution_unadapted(
                 worker_plan,
                 multiline,
                 &worker_encoding,
+                &worker_scope,
                 work,
             )
         },
@@ -750,6 +757,7 @@ fn grep_files_with_budget_source_and_execution_unadapted(
                         exact,
                         multiline,
                         &search_encoding,
+                        scope,
                         Some(&exact_work),
                     ) {
                         Ok(outcome) => (outcome, true),
@@ -910,17 +918,50 @@ fn search_candidate(
     plan: GrepSearchPlan,
     multiline: bool,
     encoding: &SearchEncoding,
+    scope: &ReadScope,
     operation: Option<&dyn WorkCheckpoint>,
 ) -> Result<SearchOutcome, SearchFailure> {
     if let Some(content_multiline) = plan.content_multiline() {
         debug_assert_eq!(content_multiline, multiline);
     }
-    let snapshot = match capture_classify(
-        candidate,
-        encoding.explicit.as_deref(),
-        encoding.fallback.as_deref(),
-        operation,
-    ) {
+    let capture = if scope.is_restricted() {
+        let routed = scope
+            .route_with_formatter(&candidate.native, search_display_path)
+            .map_err(SearchFailure::Message)?;
+        let file = match routed.capability.open(&routed.relative) {
+            Ok(file) => file.into_std(),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                return Ok(SearchOutcome {
+                    result: None,
+                    entries_seen: 0,
+                    skip: Some(CandidateSkip::ChangedWhileSearched),
+                    transcoding_note: None,
+                    used_fallback: false,
+                });
+            }
+            Err(error) => {
+                return Err(SearchFailure::Message(io_error_message(
+                    &candidate.native,
+                    &error,
+                )));
+            }
+        };
+        capture_classify_open_file(
+            file,
+            candidate.clone(),
+            encoding.explicit.as_deref(),
+            encoding.fallback.as_deref(),
+            operation,
+        )
+    } else {
+        capture_classify(
+            candidate,
+            encoding.explicit.as_deref(),
+            encoding.fallback.as_deref(),
+            operation,
+        )
+    };
+    let snapshot = match capture {
         Ok(CaptureDisposition::Searchable(snapshot)) => snapshot,
         Ok(CaptureDisposition::BinarySkipped(proof)) => {
             debug_assert!(matches!(
@@ -1149,9 +1190,18 @@ fn search_candidate_for_work(
     plan: GrepSearchPlan,
     multiline: bool,
     encoding: &SearchEncoding,
+    scope: &ReadScope,
     work: &WorkCtx,
 ) -> Result<Result<SearchOutcome, SearchFailure>, WorkStop> {
-    match search_candidate(candidate, matcher, plan, multiline, encoding, Some(work)) {
+    match search_candidate(
+        candidate,
+        matcher,
+        plan,
+        multiline,
+        encoding,
+        scope,
+        Some(work),
+    ) {
         Err(SearchFailure::Cancelled) => Err(WorkStop::RequestCancelled),
         Err(SearchFailure::EpochRetired) => Err(WorkStop::EpochRetired),
         outcome => Ok(outcome),
@@ -2701,6 +2751,7 @@ mod tests {
                 explicit: None,
                 fallback: None,
             },
+            &ReadScope::unrestricted(),
             None,
         ) {
             Ok(outcome) => outcome,
@@ -3656,6 +3707,96 @@ mod tests {
         };
         assert!(text.starts_with("Permission denied: "), "{text}");
         assert!(!text.contains("secret-symlink-grep-content"), "{text}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn restricted_grep_keeps_stable_file_symlinks_in_configured_roots() {
+        let fixture = tempfile::tempdir().unwrap();
+        let left = fixture.path().join("left");
+        let right = fixture.path().join("right");
+        std::fs::create_dir(&left).unwrap();
+        std::fs::create_dir(&right).unwrap();
+        std::fs::write(left.join("same-target.txt"), b"stable-hit\n").unwrap();
+        std::fs::write(right.join("cross-target.txt"), b"stable-hit\n").unwrap();
+        std::os::unix::fs::symlink("same-target.txt", left.join("same-link.txt")).unwrap();
+        std::os::unix::fs::symlink(right.join("cross-target.txt"), left.join("cross-link.txt"))
+            .unwrap();
+        let scope = ReadScope::from_allow_roots(&[left.clone(), right]).unwrap();
+        let mut request = grep_request(&left, OutputMode::FilesWithMatches);
+        request.pattern = "stable-hit".to_string();
+        let restricted = grep_files_with_scope(request.clone(), CancellationToken::new(), &scope);
+        let unrestricted = grep_files_with_scope(
+            request,
+            CancellationToken::new(),
+            &ReadScope::unrestricted(),
+        );
+        assert_eq!(restricted, unrestricted);
+        let ToolContent::Text(text) = &restricted.content[0] else {
+            panic!("expected text response: {restricted:?}");
+        };
+        assert!(text.contains("same-link.txt"), "{text}");
+        assert!(text.contains("cross-link.txt"), "{text}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn restricted_grep_rejects_candidate_after_final_component_swap() {
+        let fixture = tempfile::tempdir().unwrap();
+        let root = fixture.path().join("allowed");
+        std::fs::create_dir(&root).unwrap();
+        let path = root.join("inside.txt");
+        let old = root.join("inside.old");
+        std::fs::write(&path, b"original-grep-hit\n").unwrap();
+        let path_for_hook = path.clone();
+        let old_for_hook = old.clone();
+        let _hook =
+            crate::file_snapshot::tests::OriginalOpenObserverGuard::install(Arc::new(move |_| {
+                if path_for_hook.exists() {
+                    std::fs::rename(&path_for_hook, &old_for_hook).unwrap();
+                    std::fs::write(&path_for_hook, b"replacement-grep-hit\n").unwrap();
+                }
+            }));
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+        let mut request = grep_request(&root, OutputMode::Content);
+        request.pattern = "original-grep-hit".to_string();
+        let response = grep_files_with_scope(request, CancellationToken::new(), &scope);
+        let ToolContent::Text(text) = &response.content[0] else {
+            panic!("expected text response: {response:?}");
+        };
+        assert!(text.contains("changed while being searched"), "{text}");
+        assert!(!text.contains("original-grep-hit"), "{text}");
+        assert!(!text.contains("replacement-grep-hit"), "{text}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn restricted_grep_rejects_same_length_same_mtime_change_after_open() {
+        use std::os::unix::fs::MetadataExt;
+
+        let fixture = tempfile::tempdir().unwrap();
+        let root = fixture.path().join("allowed");
+        std::fs::create_dir(&root).unwrap();
+        let path = root.join("inside.txt");
+        std::fs::write(&path, b"original-grep\n").unwrap();
+        let modified = std::fs::metadata(&path).unwrap();
+        let mtime =
+            filetime::FileTime::from_unix_time(modified.mtime(), modified.mtime_nsec() as u32);
+        let path_for_hook = path.clone();
+        let _hook =
+            crate::file_snapshot::tests::OriginalOpenObserverGuard::install(Arc::new(move |_| {
+                std::fs::write(&path_for_hook, b"replaced-grep\n").unwrap();
+                filetime::set_file_mtime(&path_for_hook, mtime).unwrap();
+            }));
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+        let mut request = grep_request(&root, OutputMode::FilesWithMatches);
+        request.pattern = "replaced-grep".to_string();
+        let response = grep_files_with_scope(request, CancellationToken::new(), &scope);
+        let ToolContent::Text(text) = &response.content[0] else {
+            panic!("expected text response: {response:?}");
+        };
+        assert!(text.contains("changed while being searched"), "{text}");
+        assert!(!text.contains("replaced-grep"), "{text}");
     }
 
     #[test]

--- a/src/grep_tool.rs
+++ b/src/grep_tool.rs
@@ -9,9 +9,7 @@ use crate::encoding::{
     canonical_encoding_label, validate_snapshot_encoding,
 };
 use crate::file_executor::GrepGlobExecutor;
-use crate::file_snapshot::{
-    CaptureDisposition, CaptureFailure, capture_classify, capture_classify_open_file,
-};
+use crate::file_snapshot::{CaptureDisposition, CaptureFailure, capture_classify_open_file};
 use crate::grep_sink::{
     CapturedLine, ContentEntry, ContentSpec, FileResult, GrepSearchPlan, GrepSinkError,
     LineMatchSpan, PlanSink,
@@ -924,43 +922,34 @@ fn search_candidate(
     if let Some(content_multiline) = plan.content_multiline() {
         debug_assert_eq!(content_multiline, multiline);
     }
-    let capture = if scope.is_restricted() {
-        let routed = scope
-            .route_with_formatter(&candidate.native, search_display_path)
-            .map_err(SearchFailure::Message)?;
-        let file = match routed.capability.open(&routed.relative) {
-            Ok(file) => file.into_std(),
-            Err(error) if error.kind() == io::ErrorKind::NotFound => {
-                return Ok(SearchOutcome {
-                    result: None,
-                    entries_seen: 0,
-                    skip: Some(CandidateSkip::ChangedWhileSearched),
-                    transcoding_note: None,
-                    used_fallback: false,
-                });
-            }
-            Err(error) => {
-                return Err(SearchFailure::Message(io_error_message(
-                    &candidate.native,
-                    &error,
-                )));
-            }
-        };
-        capture_classify_open_file(
-            file,
-            candidate.clone(),
-            encoding.explicit.as_deref(),
-            encoding.fallback.as_deref(),
-            operation,
-        )
-    } else {
-        capture_classify(
-            candidate,
-            encoding.explicit.as_deref(),
-            encoding.fallback.as_deref(),
-            operation,
-        )
+    let routed = scope
+        .route_with_formatter(&candidate.native, search_display_path)
+        .map_err(SearchFailure::Message)?;
+    let file = match routed.capability.open(&routed.relative) {
+        Ok(file) => file.into_std(),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return Ok(SearchOutcome {
+                result: None,
+                entries_seen: 0,
+                skip: Some(CandidateSkip::ChangedWhileSearched),
+                transcoding_note: None,
+                used_fallback: false,
+            });
+        }
+        Err(error) => {
+            return Err(SearchFailure::Message(io_error_message(
+                &candidate.native,
+                &error,
+            )));
+        }
     };
+    let capture = capture_classify_open_file(
+        file,
+        candidate.clone(),
+        encoding.explicit.as_deref(),
+        encoding.fallback.as_deref(),
+        operation,
+    );
     let snapshot = match capture {
         Ok(CaptureDisposition::Searchable(snapshot)) => snapshot,
         Ok(CaptureDisposition::BinarySkipped(proof)) => {
@@ -3741,32 +3730,45 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn restricted_grep_rejects_candidate_after_final_component_swap() {
-        let fixture = tempfile::tempdir().unwrap();
-        let root = fixture.path().join("allowed");
-        std::fs::create_dir(&root).unwrap();
-        let path = root.join("inside.txt");
-        let old = root.join("inside.old");
-        std::fs::write(&path, b"original-grep-hit\n").unwrap();
-        let path_for_hook = path.clone();
-        let old_for_hook = old.clone();
-        let _hook =
-            crate::file_snapshot::tests::OriginalOpenObserverGuard::install(Arc::new(move |_| {
-                if path_for_hook.exists() {
-                    std::fs::rename(&path_for_hook, &old_for_hook).unwrap();
-                    std::fs::write(&path_for_hook, b"replacement-grep-hit\n").unwrap();
-                }
-            }));
-        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
-        let mut request = grep_request(&root, OutputMode::Content);
-        request.pattern = "original-grep-hit".to_string();
-        let response = grep_files_with_scope(request, CancellationToken::new(), &scope);
-        let ToolContent::Text(text) = &response.content[0] else {
-            panic!("expected text response: {response:?}");
-        };
-        assert!(text.contains("changed while being searched"), "{text}");
-        assert!(!text.contains("original-grep-hit"), "{text}");
-        assert!(!text.contains("replacement-grep-hit"), "{text}");
+    fn grep_rejects_candidate_after_final_component_swap_in_both_modes() {
+        for restricted in [false, true] {
+            let fixture = tempfile::tempdir().unwrap();
+            let root = fixture.path().join("allowed");
+            std::fs::create_dir(&root).unwrap();
+            let path = root.join("inside.txt");
+            let old = root.join("inside.old");
+            std::fs::write(&path, b"original-grep-hit\n").unwrap();
+            let path_for_hook = path.clone();
+            let old_for_hook = old.clone();
+            let _hook = crate::file_snapshot::tests::OriginalOpenObserverGuard::install(Arc::new(
+                move |_| {
+                    if path_for_hook.exists() {
+                        std::fs::rename(&path_for_hook, &old_for_hook).unwrap();
+                        std::fs::write(&path_for_hook, b"replacement-grep-hit\n").unwrap();
+                    }
+                },
+            ));
+            let scope = if restricted {
+                ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap()
+            } else {
+                ReadScope::unrestricted()
+            };
+            let mut request = grep_request(&root, OutputMode::Content);
+            request.pattern = "original-grep-hit".to_string();
+            let response = grep_files_with_scope(request, CancellationToken::new(), &scope);
+            let ToolContent::Text(text) = &response.content[0] else {
+                panic!("expected text response: {response:?}");
+            };
+            assert!(
+                text.contains("changed while being searched"),
+                "{restricted}: {text}"
+            );
+            assert!(!text.contains("original-grep-hit"), "{restricted}: {text}");
+            assert!(
+                !text.contains("replacement-grep-hit"),
+                "{restricted}: {text}"
+            );
+        }
     }
 
     #[cfg(unix)]

--- a/src/grep_tool.rs
+++ b/src/grep_tool.rs
@@ -314,7 +314,7 @@ fn grep_files_with_budget(request: GrepRequest, budget: usize) -> ToolResponse {
         rmcp::model::RequestId::String(Arc::from("test-grep")),
         CancellationToken::new(),
     );
-    let response = grep_files_with_budget_source_and_execution(
+    let response = grep_files_with_budget_source_and_execution_scoped(
         request,
         budget,
         "FASTCTX_TOKEN_BUDGET",
@@ -322,6 +322,7 @@ fn grep_files_with_budget(request: GrepRequest, budget: usize) -> ToolResponse {
         None,
         operation,
         Arc::new(GrepGlobExecutor::with_test_parallelism(1)),
+        &ReadScope::unrestricted(),
     );
     guard.disarm();
     response
@@ -335,7 +336,7 @@ fn grep_files_with_budget_source_and_operation(
     operation: Option<&OperationCtx>,
 ) -> ToolResponse {
     if let Some(operation) = operation {
-        return grep_files_with_budget_source_and_execution(
+        return grep_files_with_budget_source_and_execution_scoped(
             request,
             budget,
             budget_variable,
@@ -343,13 +344,14 @@ fn grep_files_with_budget_source_and_operation(
             None,
             operation.clone(),
             Arc::new(GrepGlobExecutor::with_test_parallelism(1)),
+            &ReadScope::unrestricted(),
         );
     }
     let (mut guard, operation) = RequestWorkGuard::new(
         rmcp::model::RequestId::String(Arc::from("test-grep-operation")),
         CancellationToken::new(),
     );
-    let response = grep_files_with_budget_source_and_execution(
+    let response = grep_files_with_budget_source_and_execution_scoped(
         request,
         budget,
         budget_variable,
@@ -357,6 +359,7 @@ fn grep_files_with_budget_source_and_operation(
         None,
         operation,
         Arc::new(GrepGlobExecutor::with_test_parallelism(1)),
+        &ReadScope::unrestricted(),
     );
     guard.disarm();
     response
@@ -372,7 +375,7 @@ fn grep_files_with_budget_and_parallelism(
         rmcp::model::RequestId::String(Arc::from(format!("test-grep-p{parallelism}"))),
         CancellationToken::new(),
     );
-    let response = grep_files_with_budget_source_and_execution(
+    let response = grep_files_with_budget_source_and_execution_scoped(
         request,
         budget,
         "FASTCTX_TOKEN_BUDGET",
@@ -380,6 +383,7 @@ fn grep_files_with_budget_and_parallelism(
         None,
         operation,
         Arc::new(GrepGlobExecutor::with_test_parallelism(parallelism)),
+        &ReadScope::unrestricted(),
     );
     guard.disarm();
     response
@@ -405,7 +409,7 @@ fn grep_files_with_parallelism_and_capture_limit(
     );
     let executor = Arc::new(GrepGlobExecutor::with_test_parallelism(parallelism));
     let probe = Arc::new(GrepExecutionProbe::default());
-    let response = grep_files_with_budget_source_and_execution(
+    let response = grep_files_with_budget_source_and_execution_scoped(
         request,
         budget,
         "FASTCTX_TOKEN_BUDGET",
@@ -413,6 +417,7 @@ fn grep_files_with_parallelism_and_capture_limit(
         Some(Arc::clone(&probe)),
         operation,
         Arc::clone(&executor),
+        &ReadScope::unrestricted(),
     );
     guard.disarm();
     executor.wait_for_test_quiescence();
@@ -421,29 +426,6 @@ fn grep_files_with_parallelism_and_capture_limit(
         probe.exact_retries.load(Ordering::Acquire),
         executor.test_burst_ledger(),
         executor.test_ticket_ledger(),
-    )
-}
-
-#[cfg(test)]
-fn grep_files_with_budget_source_and_execution(
-    request: GrepRequest,
-    budget: usize,
-    budget_variable: &str,
-    capture_heap_limit_bytes: usize,
-    #[cfg(test)] execution_probe: Option<Arc<GrepExecutionProbe>>,
-    operation: OperationCtx,
-    executor: Arc<GrepGlobExecutor>,
-) -> ToolResponse {
-    grep_files_with_budget_source_and_execution_scoped(
-        request,
-        budget,
-        budget_variable,
-        capture_heap_limit_bytes,
-        #[cfg(test)]
-        execution_probe,
-        operation,
-        executor,
-        &ReadScope::unrestricted(),
     )
 }
 
@@ -3623,7 +3605,16 @@ mod tests {
     }
 
     #[test]
-    fn scoped_grep_denies_explicit_outside_root_and_lexical_prefixes() {
+    fn scoped_grep_denies_outside_direct_and_recursive_symlink_targets() {
+        let assert_denied = |response: ToolResponse, secret: &str| {
+            assert!(response.is_error, "{response:?}");
+            let ToolContent::Text(text) = &response.content[0] else {
+                panic!("expected text error");
+            };
+            assert!(text.starts_with("Permission denied: "), "{text}");
+            assert!(!text.contains(secret), "{text}");
+        };
+
         let fixture = tempfile::tempdir().unwrap();
         let root = fixture.path().join("work");
         let sibling = fixture.path().join("work-secret");
@@ -3650,52 +3641,44 @@ mod tests {
             encoding: None,
             fallback_encoding: None,
         };
-        let response = grep_files_with_scope(request, CancellationToken::new(), &scope);
-        assert!(response.is_error, "{response:?}");
-        let ToolContent::Text(text) = &response.content[0] else {
-            panic!("expected text error");
-        };
-        assert!(text.starts_with("Permission denied: "), "{text}");
-        assert!(!text.contains("secret-grep-content"), "{text}");
-    }
+        assert_denied(
+            grep_files_with_scope(request, CancellationToken::new(), &scope),
+            "secret-grep-content",
+        );
 
-    #[cfg(unix)]
-    #[test]
-    fn scoped_grep_denies_recursive_file_symlink_without_returning_target_content() {
-        let fixture = tempfile::tempdir().unwrap();
-        let root = fixture.path().join("allowed");
-        let outside = fixture.path().join("outside.txt");
-        std::fs::create_dir(&root).unwrap();
-        std::fs::write(&outside, b"secret-symlink-grep-content").unwrap();
-        let link = root.join("outside-link.txt");
-        std::os::unix::fs::symlink(&outside, &link).unwrap();
-        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
-        let mut request = GrepRequest {
-            pattern: "secret-symlink-grep-content".to_string(),
-            path: Some(display_path(&root)),
-            glob: None,
-            file_type: None,
-            output_mode: Some(OutputMode::Content),
-            case_insensitive: None,
-            line_numbers: None,
-            only_matching: None,
-            before_context: None,
-            after_context: None,
-            context: None,
-            multiline: None,
-            head_limit: None,
-            offset: None,
-            encoding: None,
-            fallback_encoding: None,
-        };
-        request.glob = Some("**/*".to_string());
-        let response = grep_files_with_scope(request, CancellationToken::new(), &scope);
-        assert!(response.is_error, "{response:?}");
-        let ToolContent::Text(text) = &response.content[0] else {
-            panic!("expected text error");
-        };
-        assert!(text.starts_with("Permission denied: "), "{text}");
-        assert!(!text.contains("secret-symlink-grep-content"), "{text}");
+        #[cfg(unix)]
+        {
+            let fixture = tempfile::tempdir().unwrap();
+            let root = fixture.path().join("allowed");
+            let outside = fixture.path().join("outside.txt");
+            std::fs::create_dir(&root).unwrap();
+            std::fs::write(&outside, b"secret-symlink-grep-content").unwrap();
+            let link = root.join("outside-link.txt");
+            std::os::unix::fs::symlink(&outside, &link).unwrap();
+            let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+            let request = GrepRequest {
+                pattern: "secret-symlink-grep-content".to_string(),
+                path: Some(display_path(&root)),
+                glob: Some("**/*".to_string()),
+                file_type: None,
+                output_mode: Some(OutputMode::Content),
+                case_insensitive: None,
+                line_numbers: None,
+                only_matching: None,
+                before_context: None,
+                after_context: None,
+                context: None,
+                multiline: None,
+                head_limit: None,
+                offset: None,
+                encoding: None,
+                fallback_encoding: None,
+            };
+            assert_denied(
+                grep_files_with_scope(request, CancellationToken::new(), &scope),
+                "secret-symlink-grep-content",
+            );
+        }
     }
 
     #[cfg(unix)]

--- a/src/grep_tool.rs
+++ b/src/grep_tool.rs
@@ -20,8 +20,9 @@ use crate::operation::{
 };
 use crate::ordered_window::{OrderedError, for_each_ordered};
 use crate::path_codec::{
-    PathRecord as Candidate, RootRequirement, io_error_message, resolve_search_root,
+    PathRecord as Candidate, RootRequirement, io_error_message, resolve_search_root_with_scope,
 };
+use crate::paths::ReadScope;
 use crate::render_plan::{
     DetailRenderGraph, LineRenderGraph, LineRenderView, RenderPlanError, SharedLineRenderGraph,
 };
@@ -235,6 +236,14 @@ struct SearchEncoding {
 /// matching, sorting, rendering, and token verification. A cancelled operation
 /// returns an error response and never exposes a partial success body.
 pub fn grep_files(request: GrepRequest, cancellation: CancellationToken) -> ToolResponse {
+    grep_files_with_scope(request, cancellation, &ReadScope::unrestricted())
+}
+
+pub(crate) fn grep_files_with_scope(
+    request: GrepRequest,
+    cancellation: CancellationToken,
+    scope: &ReadScope,
+) -> ToolResponse {
     let budget = match tool_token_budget(GREP_TOKEN_BUDGET_ENV) {
         Ok(budget) => budget,
         Err(message) => {
@@ -249,7 +258,7 @@ pub fn grep_files(request: GrepRequest, cancellation: CancellationToken) -> Tool
         rmcp::model::RequestId::String(Arc::from("direct-grep")),
         cancellation,
     );
-    let response = grep_files_with_budget_source_and_execution(
+    let response = grep_files_with_budget_source_and_execution_scoped(
         request,
         budget.value,
         budget.variable,
@@ -258,6 +267,7 @@ pub fn grep_files(request: GrepRequest, cancellation: CancellationToken) -> Tool
         None,
         operation,
         GrepGlobExecutor::shared(),
+        scope,
     );
     guard.disarm();
     response
@@ -267,6 +277,7 @@ pub fn grep_files(request: GrepRequest, cancellation: CancellationToken) -> Tool
 pub(crate) fn grep_files_cancellable(
     operation: OperationCtx,
     executor: Arc<GrepGlobExecutor>,
+    scope: ReadScope,
     request: GrepRequest,
 ) -> Result<ToolResponse, OpError> {
     let work = operation.inline_work();
@@ -281,7 +292,7 @@ pub(crate) fn grep_files_cancellable(
             .error(ErrorClass::Budget, message));
         }
     };
-    let response = grep_files_with_budget_source_and_execution(
+    let response = grep_files_with_budget_source_and_execution_scoped(
         request,
         budget.value,
         budget.variable,
@@ -290,6 +301,7 @@ pub(crate) fn grep_files_cancellable(
         None,
         operation.clone(),
         executor,
+        &scope,
     );
     work.check_inline()?;
     Ok(response)
@@ -411,6 +423,7 @@ fn grep_files_with_parallelism_and_capture_limit(
     )
 }
 
+#[cfg(test)]
 fn grep_files_with_budget_source_and_execution(
     request: GrepRequest,
     budget: usize,
@@ -419,6 +432,30 @@ fn grep_files_with_budget_source_and_execution(
     #[cfg(test)] execution_probe: Option<Arc<GrepExecutionProbe>>,
     operation: OperationCtx,
     executor: Arc<GrepGlobExecutor>,
+) -> ToolResponse {
+    grep_files_with_budget_source_and_execution_scoped(
+        request,
+        budget,
+        budget_variable,
+        capture_heap_limit_bytes,
+        #[cfg(test)]
+        execution_probe,
+        operation,
+        executor,
+        &ReadScope::unrestricted(),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn grep_files_with_budget_source_and_execution_scoped(
+    request: GrepRequest,
+    budget: usize,
+    budget_variable: &str,
+    capture_heap_limit_bytes: usize,
+    #[cfg(test)] execution_probe: Option<Arc<GrepExecutionProbe>>,
+    operation: OperationCtx,
+    executor: Arc<GrepGlobExecutor>,
+    scope: &ReadScope,
 ) -> ToolResponse {
     let adapter = ErrorBudgetAdapter::new(budget, budget_variable);
     adapter.adapt(grep_files_with_budget_source_and_execution_unadapted(
@@ -430,9 +467,11 @@ fn grep_files_with_budget_source_and_execution(
         execution_probe,
         operation,
         executor,
+        scope,
     ))
 }
 
+#[allow(clippy::too_many_arguments)]
 fn grep_files_with_budget_source_and_execution_unadapted(
     request: GrepRequest,
     budget: usize,
@@ -441,9 +480,14 @@ fn grep_files_with_budget_source_and_execution_unadapted(
     #[cfg(test)] execution_probe: Option<Arc<GrepExecutionProbe>>,
     operation: OperationCtx,
     executor: Arc<GrepGlobExecutor>,
+    scope: &ReadScope,
 ) -> ToolResponse {
     let root_input = request.path.clone();
-    let root = match resolve_search_root(root_input.as_deref(), RootRequirement::FileOrDirectory) {
+    let root = match resolve_search_root_with_scope(
+        root_input.as_deref(),
+        RootRequirement::FileOrDirectory,
+        scope,
+    ) {
         Ok(root) => root,
         Err(message) => return ToolResponse::error(message),
     };
@@ -2569,10 +2613,12 @@ mod tests {
         build_matcher, capture_limit_error, finish_grep_graph, format_content_mode,
         format_files_mode, grep_files_with_budget, grep_files_with_budget_and_parallelism,
         grep_files_with_budget_source_and_operation, grep_files_with_parallelism_and_capture_limit,
-        normalize_multiline_pattern, replay_compat_binary_probes, search_candidate,
-        search_error_message, snapshot_error_message,
+        grep_files_with_scope, normalize_multiline_pattern, replay_compat_binary_probes,
+        search_candidate, search_error_message, snapshot_error_message,
     };
     use crate::operation::{RequestWorkGuard, TestStage};
+    use crate::path_codec::display_path as search_display_path;
+    use crate::paths::{ReadScope, display_path};
     use crate::{ToolContent, ToolResponse};
     use filetime::{FileTime, set_file_mtime};
     use rmcp::model::RequestId;
@@ -3534,5 +3580,149 @@ mod tests {
             snapshot_error_message(&candidate, &io::Error::other("disk full")),
             "Cannot create a stable search snapshot for /large.txt: disk full. Free temporary-disk space or retry after the file stops changing."
         );
+    }
+
+    #[test]
+    fn scoped_grep_denies_explicit_outside_root_and_lexical_prefixes() {
+        let fixture = tempfile::tempdir().unwrap();
+        let root = fixture.path().join("work");
+        let sibling = fixture.path().join("work-secret");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::create_dir(&sibling).unwrap();
+        let outside = sibling.join("outside.txt");
+        std::fs::write(&outside, b"secret-grep-content").unwrap();
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+        let request = GrepRequest {
+            pattern: "secret-grep-content".to_string(),
+            path: Some(display_path(&outside)),
+            glob: None,
+            file_type: None,
+            output_mode: Some(OutputMode::Content),
+            case_insensitive: None,
+            line_numbers: None,
+            only_matching: None,
+            before_context: None,
+            after_context: None,
+            context: None,
+            multiline: None,
+            head_limit: None,
+            offset: None,
+            encoding: None,
+            fallback_encoding: None,
+        };
+        let response = grep_files_with_scope(request, CancellationToken::new(), &scope);
+        assert!(response.is_error, "{response:?}");
+        let ToolContent::Text(text) = &response.content[0] else {
+            panic!("expected text error");
+        };
+        assert!(text.starts_with("Permission denied: "), "{text}");
+        assert!(!text.contains("secret-grep-content"), "{text}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn scoped_grep_denies_recursive_file_symlink_without_returning_target_content() {
+        let fixture = tempfile::tempdir().unwrap();
+        let root = fixture.path().join("allowed");
+        let outside = fixture.path().join("outside.txt");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::write(&outside, b"secret-symlink-grep-content").unwrap();
+        let link = root.join("outside-link.txt");
+        std::os::unix::fs::symlink(&outside, &link).unwrap();
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+        let mut request = GrepRequest {
+            pattern: "secret-symlink-grep-content".to_string(),
+            path: Some(display_path(&root)),
+            glob: None,
+            file_type: None,
+            output_mode: Some(OutputMode::Content),
+            case_insensitive: None,
+            line_numbers: None,
+            only_matching: None,
+            before_context: None,
+            after_context: None,
+            context: None,
+            multiline: None,
+            head_limit: None,
+            offset: None,
+            encoding: None,
+            fallback_encoding: None,
+        };
+        request.glob = Some("**/*".to_string());
+        let response = grep_files_with_scope(request, CancellationToken::new(), &scope);
+        assert!(response.is_error, "{response:?}");
+        let ToolContent::Text(text) = &response.content[0] else {
+            panic!("expected text error");
+        };
+        assert!(text.starts_with("Permission denied: "), "{text}");
+        assert!(!text.contains("secret-symlink-grep-content"), "{text}");
+    }
+
+    #[test]
+    fn restricted_relative_grep_request_has_no_cwd_diagnostics() {
+        let fixture = tempfile::tempdir().unwrap();
+        let scope = ReadScope::from_allow_roots(&[fixture.path().to_path_buf()]).unwrap();
+        let mut request = grep_request(Path::new("relative.txt"), OutputMode::Content);
+        request.path = Some("relative.txt".to_string());
+        let response = grep_files_with_scope(request, CancellationToken::new(), &scope);
+        let ToolContent::Text(text) = &response.content[0] else {
+            panic!("expected text error");
+        };
+        assert_eq!(text, "Path must be absolute: relative.txt");
+    }
+
+    #[test]
+    fn scoped_grep_denial_uses_line_safe_encoded_path_display() {
+        let fixture = tempfile::tempdir().unwrap();
+        let root = fixture.path().join("allowed");
+        let outside = fixture.path().join("outside\nsecret.txt");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::write(&outside, b"must-not-leak").unwrap();
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+        let request = GrepRequest {
+            pattern: "must-not-leak".to_string(),
+            path: Some(search_display_path(&outside)),
+            glob: None,
+            file_type: None,
+            output_mode: Some(OutputMode::Content),
+            case_insensitive: None,
+            line_numbers: None,
+            only_matching: None,
+            before_context: None,
+            after_context: None,
+            context: None,
+            multiline: None,
+            head_limit: None,
+            offset: None,
+            encoding: None,
+            fallback_encoding: None,
+        };
+        let response = grep_files_with_scope(request, CancellationToken::new(), &scope);
+        let ToolContent::Text(text) = &response.content[0] else {
+            panic!("expected text error");
+        };
+        assert!(text.contains("~fastctx~b"), "{text}");
+        assert!(!text.contains('\n'), "{text:?}");
+        assert!(!text.contains("must-not-leak"), "{text}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn scoped_grep_symlink_resolution_errors_use_line_safe_encoded_paths() {
+        let fixture = tempfile::tempdir().unwrap();
+        let root = fixture.path().join("allowed");
+        std::fs::create_dir(&root).unwrap();
+        let link = root.join("loop\nname");
+        std::os::unix::fs::symlink("loop\nname", &link).unwrap();
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+        let mut request = grep_request(&root, OutputMode::FilesWithMatches);
+        request.pattern = "anything".to_string();
+        request.glob = Some("**/*".to_string());
+        let response = grep_files_with_scope(request, CancellationToken::new(), &scope);
+        let ToolContent::Text(text) = &response.content[0] else {
+            panic!("expected text error");
+        };
+        assert!(text.contains("~fastctx~b"), "{text}");
+        assert!(!text.contains('\n'), "{text:?}");
     }
 }

--- a/src/path_codec.rs
+++ b/src/path_codec.rs
@@ -1,6 +1,6 @@
 //! Lossless search-path identity, display encoding, and root resolution.
 
-use crate::paths::canonical_existing;
+use crate::paths::{ReadScope, absolute_path_required_message, canonical_existing};
 use std::ffi::{OsStr, OsString};
 use std::fmt;
 use std::fs::{self, Metadata};
@@ -141,6 +141,7 @@ pub(crate) struct ResolvedRoot {
     pub(crate) display: Arc<str>,
     pub(crate) metadata: Metadata,
     pub(crate) kind: RootKind,
+    pub(crate) scope: ReadScope,
 }
 
 impl ResolvedRoot {
@@ -152,6 +153,7 @@ impl ResolvedRoot {
             native,
             metadata,
             kind,
+            scope: ReadScope::unrestricted(),
         })
     }
 
@@ -252,9 +254,18 @@ pub(crate) fn io_error_message(path: &Path, error: &io::Error) -> String {
 }
 
 /// Resolves a grep/glob root with one explicit metadata call and no existence preflight.
+#[cfg(test)]
 pub(crate) fn resolve_search_root(
     input: Option<&str>,
     requirement: RootRequirement,
+) -> Result<ResolvedRoot, String> {
+    resolve_search_root_with_scope(input, requirement, &ReadScope::unrestricted())
+}
+
+pub(crate) fn resolve_search_root_with_scope(
+    input: Option<&str>,
+    requirement: RootRequirement,
+    scope: &ReadScope,
 ) -> Result<ResolvedRoot, String> {
     let parsed = match input {
         Some(input) => parse_input_path(input).map_err(|error| error.to_string())?,
@@ -262,32 +273,39 @@ pub(crate) fn resolve_search_root(
             .map_err(|error| format!("Cannot access the session working directory: {error}"))?,
     };
 
-    if input.is_some() && !parsed.is_absolute() {
+    if let Some(input) = input
+        && !parsed.is_absolute()
+    {
+        if scope.is_restricted() {
+            return Err(absolute_path_required_message(input));
+        }
         return Err(missing_relative_search_path_message(&parsed));
     }
 
-    let metadata = root_metadata(&parsed).map_err(|error| {
+    let authorized = scope.authorize_with_formatter(&parsed, display_path)?;
+    let metadata = root_metadata(&authorized).map_err(|error| {
         if error.kind() == io::ErrorKind::NotFound {
-            missing_absolute_search_path_message(&parsed)
+            missing_absolute_search_path_message(&authorized)
         } else {
-            io_error_message(&parsed, &error)
+            io_error_message(&authorized, &error)
         }
     })?;
-    let kind = metadata_kind(&parsed, &metadata)?;
+    let kind = metadata_kind(&authorized, &metadata)?;
     if requirement == RootRequirement::Directory && kind != RootKind::Directory {
         return Err(format!(
             "Path is not a directory: {}",
-            display_path(&parsed)
+            display_path(&authorized)
         ));
     }
 
     let canonical =
-        canonical_existing(&parsed).map_err(|error| io_error_message(&parsed, &error))?;
+        canonical_existing(&authorized).map_err(|error| io_error_message(&authorized, &error))?;
     Ok(ResolvedRoot {
         display: Arc::from(display_path(&canonical)),
         native: canonical,
         metadata,
         kind,
+        scope: scope.clone(),
     })
 }
 

--- a/src/path_codec.rs
+++ b/src/path_codec.rs
@@ -437,11 +437,7 @@ pub(crate) fn resolve_search_root_with_scope(
         ));
     }
 
-    let canonical = if scope.is_restricted() {
-        authorized
-    } else {
-        canonical_existing(&authorized).map_err(|error| io_error_message(&authorized, &error))?
-    };
+    let canonical = authorized;
     Ok(ResolvedRoot {
         display: Arc::from(display_path(&canonical)),
         native: canonical,

--- a/src/path_codec.rs
+++ b/src/path_codec.rs
@@ -78,6 +78,86 @@ impl FileIdentityHint {
             }
         }
     }
+
+    fn from_cap_metadata(metadata: &cap_std::fs::Metadata) -> Self {
+        #[cfg(unix)]
+        {
+            use cap_std::fs::MetadataExt;
+            Self {
+                len: metadata.len(),
+                modified: metadata.modified().ok().map(|time| time.into_std()),
+                device: metadata.dev(),
+                inode: metadata.ino(),
+                modified_seconds: metadata.mtime(),
+                modified_nanoseconds: metadata.mtime_nsec(),
+                changed_seconds: metadata.ctime(),
+                changed_nanoseconds: metadata.ctime_nsec(),
+            }
+        }
+        #[cfg(windows)]
+        {
+            use cap_std::fs::MetadataExt;
+            Self {
+                len: metadata.len(),
+                modified: metadata.modified().ok().map(|time| time.into_std()),
+                creation_time: metadata.creation_time(),
+                last_write_time: metadata.last_write_time(),
+                attributes: metadata.file_attributes(),
+            }
+        }
+    }
+}
+
+pub(crate) trait MetadataView {
+    fn is_file(&self) -> bool;
+    fn is_dir(&self) -> bool;
+    fn modified(&self) -> io::Result<SystemTime>;
+    fn len(&self) -> u64;
+    fn identity_hint(&self) -> FileIdentityHint;
+}
+
+impl MetadataView for Metadata {
+    fn is_file(&self) -> bool {
+        self.is_file()
+    }
+
+    fn is_dir(&self) -> bool {
+        self.is_dir()
+    }
+
+    fn modified(&self) -> io::Result<SystemTime> {
+        self.modified()
+    }
+
+    fn len(&self) -> u64 {
+        self.len()
+    }
+
+    fn identity_hint(&self) -> FileIdentityHint {
+        FileIdentityHint::from_metadata(self)
+    }
+}
+
+impl MetadataView for cap_std::fs::Metadata {
+    fn is_file(&self) -> bool {
+        self.is_file()
+    }
+
+    fn is_dir(&self) -> bool {
+        self.is_dir()
+    }
+
+    fn modified(&self) -> io::Result<SystemTime> {
+        self.modified().map(|time| time.into_std())
+    }
+
+    fn len(&self) -> u64 {
+        self.len()
+    }
+
+    fn identity_hint(&self) -> FileIdentityHint {
+        FileIdentityHint::from_cap_metadata(self)
+    }
 }
 
 /// One candidate path with separate native identity and canonical model-facing keys.
@@ -109,10 +189,10 @@ impl PathRecord {
     }
 
     /// Captures walker metadata, optionally requiring the modification-time sort key.
-    pub(crate) fn from_metadata(
+    pub(crate) fn from_metadata<M: MetadataView>(
         native: &Path,
         match_root: &Path,
-        metadata: &Metadata,
+        metadata: &M,
         include_modified: bool,
     ) -> io::Result<Self> {
         let mut record = Self::without_metadata(native, match_root);
@@ -122,7 +202,7 @@ impl PathRecord {
             None
         };
         record.traversal_len_hint = Some(metadata.len());
-        record.traversal_fingerprint = Some(FileIdentityHint::from_metadata(metadata));
+        record.traversal_fingerprint = Some(metadata.identity_hint());
         Ok(record)
     }
 }
@@ -134,12 +214,55 @@ pub(crate) enum RootKind {
     Directory,
 }
 
+#[derive(Debug)]
+pub(crate) enum RootMetadata {
+    Ambient(Metadata),
+    Scoped(cap_std::fs::Metadata),
+}
+
+impl MetadataView for RootMetadata {
+    fn is_file(&self) -> bool {
+        match self {
+            Self::Ambient(metadata) => metadata.is_file(),
+            Self::Scoped(metadata) => metadata.is_file(),
+        }
+    }
+
+    fn is_dir(&self) -> bool {
+        match self {
+            Self::Ambient(metadata) => metadata.is_dir(),
+            Self::Scoped(metadata) => metadata.is_dir(),
+        }
+    }
+
+    fn modified(&self) -> io::Result<SystemTime> {
+        match self {
+            Self::Ambient(metadata) => metadata.modified(),
+            Self::Scoped(metadata) => metadata.modified().map(|time| time.into_std()),
+        }
+    }
+
+    fn len(&self) -> u64 {
+        match self {
+            Self::Ambient(metadata) => metadata.len(),
+            Self::Scoped(metadata) => metadata.len(),
+        }
+    }
+
+    fn identity_hint(&self) -> FileIdentityHint {
+        match self {
+            Self::Ambient(metadata) => FileIdentityHint::from_metadata(metadata),
+            Self::Scoped(metadata) => FileIdentityHint::from_cap_metadata(metadata),
+        }
+    }
+}
+
 /// A search root whose one metadata result is reused by every downstream decision.
 #[derive(Debug)]
 pub(crate) struct ResolvedRoot {
     pub(crate) native: PathBuf,
     pub(crate) display: Arc<str>,
-    pub(crate) metadata: Metadata,
+    pub(crate) metadata: RootMetadata,
     pub(crate) kind: RootKind,
     pub(crate) scope: ReadScope,
 }
@@ -151,7 +274,7 @@ impl ResolvedRoot {
         Ok(Self {
             display: Arc::from(display_path(&native)),
             native,
-            metadata,
+            metadata: RootMetadata::Ambient(metadata),
             kind,
             scope: ReadScope::unrestricted(),
         })
@@ -282,14 +405,30 @@ pub(crate) fn resolve_search_root_with_scope(
         return Err(missing_relative_search_path_message(&parsed));
     }
 
-    let authorized = scope.authorize_with_formatter(&parsed, display_path)?;
-    let metadata = root_metadata(&authorized).map_err(|error| {
-        if error.kind() == io::ErrorKind::NotFound {
-            missing_absolute_search_path_message(&authorized)
-        } else {
-            io_error_message(&authorized, &error)
-        }
-    })?;
+    let (authorized, metadata) = if scope.is_restricted() {
+        let routed = scope.route_with_formatter(&parsed, display_path)?;
+        let metadata = routed
+            .capability
+            .metadata(&routed.relative)
+            .map_err(|error| {
+                if error.kind() == io::ErrorKind::NotFound {
+                    missing_absolute_search_path_message(&routed.canonical)
+                } else {
+                    io_error_message(&routed.canonical, &error)
+                }
+            })?;
+        (routed.canonical, RootMetadata::Scoped(metadata))
+    } else {
+        let authorized = scope.authorize_with_formatter(&parsed, display_path)?;
+        let metadata = root_metadata(&authorized).map_err(|error| {
+            if error.kind() == io::ErrorKind::NotFound {
+                missing_absolute_search_path_message(&authorized)
+            } else {
+                io_error_message(&authorized, &error)
+            }
+        })?;
+        (authorized, RootMetadata::Ambient(metadata))
+    };
     let kind = metadata_kind(&authorized, &metadata)?;
     if requirement == RootRequirement::Directory && kind != RootKind::Directory {
         return Err(format!(
@@ -298,8 +437,11 @@ pub(crate) fn resolve_search_root_with_scope(
         ));
     }
 
-    let canonical =
-        canonical_existing(&authorized).map_err(|error| io_error_message(&authorized, &error))?;
+    let canonical = if scope.is_restricted() {
+        authorized
+    } else {
+        canonical_existing(&authorized).map_err(|error| io_error_message(&authorized, &error))?
+    };
     Ok(ResolvedRoot {
         display: Arc::from(display_path(&canonical)),
         native: canonical,
@@ -309,7 +451,7 @@ pub(crate) fn resolve_search_root_with_scope(
     })
 }
 
-fn metadata_kind(path: &Path, metadata: &Metadata) -> Result<RootKind, String> {
+fn metadata_kind<M: MetadataView>(path: &Path, metadata: &M) -> Result<RootKind, String> {
     if metadata.is_file() {
         Ok(RootKind::File)
     } else if metadata.is_dir() {
@@ -608,8 +750,9 @@ fn append_prefix(display: &mut String, prefix: std::path::PrefixComponent<'_>) {
 mod tests {
     use super::{
         ROOT_METADATA_CALLS, RootKind, RootRequirement, display_path, io_error_message,
-        parse_input_path, resolve_search_root,
+        parse_input_path, resolve_search_root, resolve_search_root_with_scope,
     };
+    use crate::paths::ReadScope;
     use std::path::{Path, PathBuf};
 
     #[test]
@@ -701,6 +844,23 @@ mod tests {
         .unwrap();
         assert_eq!(root.native, dunce::canonicalize(temp.path()).unwrap());
         ROOT_METADATA_CALLS.with(|calls| assert_eq!(calls.get(), 1));
+    }
+
+    #[test]
+    fn restricted_root_resolution_uses_capability_metadata_only() {
+        let temp = tempfile::tempdir().unwrap();
+        let scope = ReadScope::from_allow_roots(&[temp.path().to_path_buf()]).unwrap();
+
+        ROOT_METADATA_CALLS.with(|calls| calls.set(0));
+        let root = resolve_search_root_with_scope(
+            Some(temp.path().to_str().unwrap()),
+            RootRequirement::Directory,
+            &scope,
+        )
+        .unwrap();
+
+        assert_eq!(root.native, dunce::canonicalize(temp.path()).unwrap());
+        ROOT_METADATA_CALLS.with(|calls| assert_eq!(calls.get(), 0));
     }
 
     #[test]

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -3,6 +3,127 @@
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+/// Immutable canonical read-root authorization used by the MCP file tools.
+///
+/// `None` preserves FastCtx's historical unrestricted behavior when the server
+/// was started without `--allow-root`.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct ReadScope {
+    roots: Option<Arc<[PathBuf]>>,
+}
+
+impl ReadScope {
+    pub(crate) fn unrestricted() -> Self {
+        Self { roots: None }
+    }
+
+    pub(crate) fn is_restricted(&self) -> bool {
+        self.roots.is_some()
+    }
+
+    /// Canonicalizes and validates every configured root once at startup.
+    pub(crate) fn from_allow_roots(roots: &[PathBuf]) -> Result<Self, String> {
+        if roots.is_empty() {
+            return Ok(Self::unrestricted());
+        }
+        let mut canonical = Vec::with_capacity(roots.len());
+        for root in roots {
+            if !root.is_absolute() {
+                return Err(format!(
+                    "Invalid --allow-root {}: the path must be absolute.",
+                    display_path(root)
+                ));
+            }
+            let metadata = fs::metadata(root).map_err(|error| {
+                format!(
+                    "Invalid --allow-root {}: cannot access the directory ({error}).",
+                    display_path(root)
+                )
+            })?;
+            if !metadata.is_dir() {
+                return Err(format!(
+                    "Invalid --allow-root {}: the path is not a directory.",
+                    display_path(root)
+                ));
+            }
+            let root = canonical_existing(root).map_err(|error| {
+                format!(
+                    "Invalid --allow-root {}: cannot canonicalize the directory ({error}).",
+                    display_path(root)
+                )
+            })?;
+            canonical.push(root);
+        }
+        canonical.sort();
+        canonical.dedup();
+        Ok(Self {
+            roots: Some(Arc::from(canonical)),
+        })
+    }
+
+    /// Canonicalizes a target (including stable symlink targets) before callers
+    /// perform any metadata or content read, and enforces component-aware
+    /// containment against the configured roots.
+    pub(crate) fn authorize(&self, path: &Path) -> Result<PathBuf, String> {
+        self.authorize_with_formatter(path, display_path)
+    }
+
+    pub(crate) fn authorize_with_formatter(
+        &self,
+        path: &Path,
+        formatter: fn(&Path) -> String,
+    ) -> Result<PathBuf, String> {
+        let Some(roots) = &self.roots else {
+            return Ok(canonical_existing(path).unwrap_or_else(|_| path.to_path_buf()));
+        };
+        let canonical = canonical_for_authorization(path).map_err(|error| {
+            if error.kind() == io::ErrorKind::PermissionDenied {
+                self.denied_with_formatter(path, formatter)
+            } else {
+                io_error_message_with_formatter(path, &error, formatter)
+            }
+        })?;
+        if roots.iter().any(|root| canonical.starts_with(root)) {
+            Ok(canonical)
+        } else {
+            Err(self.denied_with_formatter(path, formatter))
+        }
+    }
+
+    fn denied_with_formatter(&self, path: &Path, formatter: fn(&Path) -> String) -> String {
+        format!("Permission denied: {}", formatter(path))
+    }
+}
+
+fn canonical_for_authorization(path: &Path) -> io::Result<PathBuf> {
+    match canonical_existing(path) {
+        Ok(path) => Ok(path),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            let name = path.file_name().ok_or(error)?;
+            let parent = path.parent().unwrap_or_else(|| Path::new("/"));
+            Ok(canonical_for_authorization(parent)?.join(name))
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn io_error_message_with_formatter(
+    path: &Path,
+    error: &io::Error,
+    formatter: fn(&Path) -> String,
+) -> String {
+    let display = formatter(path);
+    #[cfg(windows)]
+    if matches!(error.raw_os_error(), Some(32 | 33)) {
+        return format!("Cannot open file (locked by another process): {display}");
+    }
+    if error.kind() == io::ErrorKind::PermissionDenied {
+        return format!("Permission denied: {display}");
+    }
+    format!("Cannot open file: {display} ({error})")
+}
 
 /// Converts either user-facing separator style into a path the current platform can parse.
 pub fn parse_input_path(input: &str) -> PathBuf {
@@ -11,6 +132,10 @@ pub fn parse_input_path(input: &str) -> PathBuf {
     } else {
         PathBuf::from(input)
     }
+}
+
+pub(crate) fn absolute_path_required_message(input: &str) -> String {
+    format!("Path must be absolute: {}", input.replace('\\', "/"))
 }
 
 /// Returns an absolute display path that never depends on platform backslashes.
@@ -201,7 +326,8 @@ pub fn missing_search_path_message(input: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{file_url_note, missing_file_message, missing_search_path_message};
+    use super::{ReadScope, file_url_note, missing_file_message, missing_search_path_message};
+    use std::path::PathBuf;
 
     #[test]
     fn file_urls_are_translated_to_the_plain_path() {
@@ -249,5 +375,41 @@ mod tests {
             search.ends_with("Use V:/definitely/missing instead."),
             "{search}"
         );
+    }
+
+    #[test]
+    fn allow_root_validation_rejects_relative_missing_and_non_directory_paths() {
+        let relative = ReadScope::from_allow_roots(&[PathBuf::from("relative")]).unwrap_err();
+        assert!(relative.contains("must be absolute"), "{relative}");
+
+        let missing = tempfile::tempdir().unwrap().path().join("missing");
+        let missing_error = ReadScope::from_allow_roots(&[missing]).unwrap_err();
+        assert!(
+            missing_error.contains("cannot access the directory"),
+            "{missing_error}"
+        );
+
+        let fixture = tempfile::tempdir().unwrap();
+        let file = fixture.path().join("file.txt");
+        std::fs::write(&file, b"content").unwrap();
+        let non_directory = ReadScope::from_allow_roots(&[file]).unwrap_err();
+        assert!(non_directory.contains("not a directory"), "{non_directory}");
+    }
+
+    #[test]
+    fn allow_root_authorization_is_component_aware() {
+        let fixture = tempfile::tempdir().unwrap();
+        let root = fixture.path().join("work");
+        let sibling = fixture.path().join("work-secret");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::create_dir(&sibling).unwrap();
+        let inside = root.join("inside.txt");
+        let outside = sibling.join("outside.txt");
+        std::fs::write(&inside, b"inside").unwrap();
+        std::fs::write(&outside, b"outside").unwrap();
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+        assert!(scope.authorize(&inside).is_ok());
+        let denied = scope.authorize(&outside).unwrap_err();
+        assert!(denied.starts_with("Permission denied: "), "{denied}");
     }
 }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -135,9 +135,6 @@ impl ReadScope {
         path: &Path,
         formatter: fn(&Path) -> String,
     ) -> Result<ScopedPath, String> {
-        let Some(roots) = &self.roots else {
-            return Err("internal error: unrestricted scope has no capability root".to_string());
-        };
         let canonical = canonical_for_authorization(path).map_err(|error| {
             if error.kind() == io::ErrorKind::PermissionDenied {
                 self.denied_with_formatter(path, formatter)
@@ -145,6 +142,38 @@ impl ReadScope {
                 io_error_message_with_formatter(path, &error, formatter)
             }
         })?;
+        let Some(roots) = &self.roots else {
+            let mut root = canonical.parent().unwrap_or(canonical.as_path());
+            loop {
+                match Dir::open_ambient_dir(root, ambient_authority()) {
+                    Ok(capability) => {
+                        let relative = canonical
+                            .strip_prefix(root)
+                            .map(Path::to_path_buf)
+                            .unwrap_or_else(|_| PathBuf::from("."));
+                        return Ok(ScopedPath {
+                            display: formatter(&canonical),
+                            canonical,
+                            relative: if relative.as_os_str().is_empty() {
+                                PathBuf::from(".")
+                            } else {
+                                relative
+                            },
+                            capability: Arc::new(capability),
+                        });
+                    }
+                    Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                        let Some(parent) = root.parent() else {
+                            return Err(io_error_message_with_formatter(path, &error, formatter));
+                        };
+                        root = parent;
+                    }
+                    Err(error) => {
+                        return Err(io_error_message_with_formatter(path, &error, formatter));
+                    }
+                }
+            }
+        };
         let root = roots
             .iter()
             .filter(|root| canonical.starts_with(&root.canonical))

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,5 +1,7 @@
 //! Cross-platform input parsing, output normalization, and filesystem error translation.
 
+use cap_std::ambient_authority;
+use cap_std::fs::Dir;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -11,7 +13,23 @@ use std::sync::Arc;
 /// was started without `--allow-root`.
 #[derive(Clone, Debug, Default)]
 pub(crate) struct ReadScope {
-    roots: Option<Arc<[PathBuf]>>,
+    roots: Option<Arc<[AllowedRoot]>>,
+}
+
+#[derive(Clone, Debug)]
+struct AllowedRoot {
+    canonical: PathBuf,
+    capability: Arc<Dir>,
+}
+
+/// A path routed to an immutable startup capability. The relative locator is
+/// never interpreted by ambient filesystem APIs.
+#[derive(Clone)]
+pub(crate) struct ScopedPath {
+    pub(crate) canonical: PathBuf,
+    pub(crate) relative: PathBuf,
+    pub(crate) display: String,
+    pub(crate) capability: Arc<Dir>,
 }
 
 impl ReadScope {
@@ -54,10 +72,20 @@ impl ReadScope {
                     display_path(root)
                 )
             })?;
-            canonical.push(root);
+            let capability =
+                Dir::open_ambient_dir(&root, ambient_authority()).map_err(|error| {
+                    format!(
+                        "Invalid --allow-root {}: cannot open the directory capability ({error}).",
+                        display_path(&root)
+                    )
+                })?;
+            canonical.push(AllowedRoot {
+                canonical: root,
+                capability: Arc::new(capability),
+            });
         }
-        canonical.sort();
-        canonical.dedup();
+        canonical.sort_by(|left, right| left.canonical.cmp(&right.canonical));
+        canonical.dedup_by(|left, right| left.canonical == right.canonical);
         Ok(Self {
             roots: Some(Arc::from(canonical)),
         })
@@ -85,7 +113,10 @@ impl ReadScope {
                 io_error_message_with_formatter(path, &error, formatter)
             }
         })?;
-        if roots.iter().any(|root| canonical.starts_with(root)) {
+        if roots
+            .iter()
+            .any(|root| canonical.starts_with(&root.canonical))
+        {
             Ok(canonical)
         } else {
             Err(self.denied_with_formatter(path, formatter))
@@ -94,6 +125,50 @@ impl ReadScope {
 
     fn denied_with_formatter(&self, path: &Path, formatter: fn(&Path) -> String) -> String {
         format!("Permission denied: {}", formatter(path))
+    }
+
+    /// Routes a request to the longest matching startup capability and returns
+    /// a capability-relative locator. Canonicalization here is only routing;
+    /// all subsequent metadata, open, and traversal operations use `capability`.
+    pub(crate) fn route_with_formatter(
+        &self,
+        path: &Path,
+        formatter: fn(&Path) -> String,
+    ) -> Result<ScopedPath, String> {
+        let Some(roots) = &self.roots else {
+            return Err("internal error: unrestricted scope has no capability root".to_string());
+        };
+        let canonical = canonical_for_authorization(path).map_err(|error| {
+            if error.kind() == io::ErrorKind::PermissionDenied {
+                self.denied_with_formatter(path, formatter)
+            } else {
+                io_error_message_with_formatter(path, &error, formatter)
+            }
+        })?;
+        let root = roots
+            .iter()
+            .filter(|root| canonical.starts_with(&root.canonical))
+            .max_by_key(|root| root.canonical.components().count())
+            .ok_or_else(|| self.denied_with_formatter(path, formatter))?;
+        let relative = canonical
+            .strip_prefix(&root.canonical)
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|_| PathBuf::from("."));
+        let display = formatter(&canonical);
+        Ok(ScopedPath {
+            canonical,
+            relative: if relative.as_os_str().is_empty() {
+                PathBuf::from(".")
+            } else {
+                relative
+            },
+            display,
+            capability: Arc::clone(&root.capability),
+        })
+    }
+
+    pub(crate) fn route(&self, path: &Path) -> Result<ScopedPath, String> {
+        self.route_with_formatter(path, display_path)
     }
 }
 
@@ -394,6 +469,25 @@ mod tests {
         std::fs::write(&file, b"content").unwrap();
         let non_directory = ReadScope::from_allow_roots(&[file]).unwrap_err();
         assert!(non_directory.contains("not a directory"), "{non_directory}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn capability_roots_route_symlink_hubs_only_when_target_root_is_configured() {
+        let fixture = tempfile::tempdir().unwrap();
+        let root_a = fixture.path().join("a");
+        let root_b = fixture.path().join("b");
+        std::fs::create_dir(&root_a).unwrap();
+        std::fs::create_dir(&root_b).unwrap();
+        std::fs::write(root_b.join("inside.txt"), b"cross-root").unwrap();
+        let hub = root_a.join("hub");
+        std::os::unix::fs::symlink(&root_b, &hub).unwrap();
+        let target = hub.join("inside.txt");
+        let only_a = ReadScope::from_allow_roots(std::slice::from_ref(&root_a)).unwrap();
+        assert!(only_a.route(&target).is_err());
+        let both = ReadScope::from_allow_roots(&[root_a, root_b]).unwrap();
+        let routed = both.route(&target).unwrap();
+        assert_eq!(routed.canonical, dunce::canonicalize(&target).unwrap());
     }
 
     #[test]

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -28,7 +28,6 @@ struct AllowedRoot {
 pub(crate) struct ScopedPath {
     pub(crate) canonical: PathBuf,
     pub(crate) relative: PathBuf,
-    pub(crate) display: String,
     pub(crate) capability: Arc<Dir>,
 }
 
@@ -152,7 +151,6 @@ impl ReadScope {
                             .map(Path::to_path_buf)
                             .unwrap_or_else(|_| PathBuf::from("."));
                         return Ok(ScopedPath {
-                            display: formatter(&canonical),
                             canonical,
                             relative: if relative.as_os_str().is_empty() {
                                 PathBuf::from(".")
@@ -183,7 +181,6 @@ impl ReadScope {
             .strip_prefix(&root.canonical)
             .map(Path::to_path_buf)
             .unwrap_or_else(|_| PathBuf::from("."));
-        let display = formatter(&canonical);
         Ok(ScopedPath {
             canonical,
             relative: if relative.as_os_str().is_empty() {
@@ -191,7 +188,6 @@ impl ReadScope {
             } else {
                 relative
             },
-            display,
             capability: Arc::clone(&root.capability),
         })
     }
@@ -431,7 +427,17 @@ pub fn missing_search_path_message(input: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{ReadScope, file_url_note, missing_file_message, missing_search_path_message};
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
+
+    fn assert_denied(scope: &ReadScope, path: &Path) {
+        for result in [
+            scope.authorize(path).map(|_| ()),
+            scope.route(path).map(|_| ()),
+        ] {
+            let message = result.unwrap_err();
+            assert!(message.starts_with("Permission denied: "), "{message}");
+        }
+    }
 
     #[test]
     fn file_urls_are_translated_to_the_plain_path() {
@@ -531,8 +537,28 @@ mod tests {
         std::fs::write(&inside, b"inside").unwrap();
         std::fs::write(&outside, b"outside").unwrap();
         let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
-        assert!(scope.authorize(&inside).is_ok());
-        let denied = scope.authorize(&outside).unwrap_err();
-        assert!(denied.starts_with("Permission denied: "), "{denied}");
+        let routed = scope.route(&inside).unwrap();
+        assert_eq!(routed.canonical, dunce::canonicalize(&inside).unwrap());
+        assert_eq!(routed.relative, PathBuf::from("inside.txt"));
+        assert_denied(&scope, &outside);
+        assert_denied(
+            &scope,
+            &root.join("..").join("work-secret").join("outside.txt"),
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn allow_root_routing_denies_static_file_symlinks_to_outside_targets() {
+        let fixture = tempfile::tempdir().unwrap();
+        let root = fixture.path().join("allowed");
+        let outside = fixture.path().join("outside.txt");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::write(&outside, b"secret-target-content").unwrap();
+        let link = root.join("outside-link.txt");
+        std::os::unix::fs::symlink(&outside, &link).unwrap();
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+
+        assert_denied(&scope, &link);
     }
 }

--- a/src/read_tool/batch.rs
+++ b/src/read_tool/batch.rs
@@ -12,7 +12,6 @@ use crate::paths::{
 use serde::Serialize;
 use std::collections::HashSet;
 use std::fs;
-use std::io::Read;
 
 const MAX_BATCH_FILES: usize = 32;
 
@@ -35,12 +34,6 @@ struct PreparedEntry {
 enum PreparedOutcome {
     Content(text_file::BatchTextContent),
     Message(String),
-}
-
-#[derive(Clone, Copy)]
-enum PreparedSource<'a> {
-    File(&'a std::path::Path),
-    Handle(&'a fs::File),
 }
 
 pub(super) fn read_text_files(mut request: ReadRequest, scope: &ReadScope) -> ToolResponse {
@@ -203,78 +196,7 @@ fn prepare_entry(
             }),
         };
     }
-    if scope.is_restricted() {
-        return prepare_restricted_entry(entry, collection_budget, scope, &parsed);
-    }
-    let authorized = match scope.authorize(&parsed) {
-        Ok(path) => path,
-        Err(message) => {
-            return PreparedEntry {
-                path: input_display,
-                outcome: PreparedOutcome::Message(message),
-            };
-        }
-    };
-    let metadata = match fs::metadata(&authorized) {
-        Ok(metadata) => metadata,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            return PreparedEntry {
-                path: input_display,
-                outcome: PreparedOutcome::Message(missing_read_file_message(&entry.path)),
-            };
-        }
-        Err(error) => {
-            return PreparedEntry {
-                path: input_display,
-                outcome: PreparedOutcome::Message(io_error_message(&authorized, &error)),
-            };
-        }
-    };
-    let path = canonical_existing(&authorized).unwrap_or(authorized);
-    let path_display = display_path(&path);
-    if metadata.is_dir() {
-        return PreparedEntry {
-            path: path_display.clone(),
-            outcome: PreparedOutcome::Message(format!(
-                "{path_display} is a directory, not a file. Use the glob tool to list its contents."
-            )),
-        };
-    }
-    if !metadata.is_file() {
-        return PreparedEntry {
-            path: path_display.clone(),
-            outcome: PreparedOutcome::Message(format!(
-                "Cannot read non-regular file: {path_display}. Only regular files are supported."
-            )),
-        };
-    }
-    let mut prefix = Vec::new();
-    if let Err(error) =
-        fs::File::open(&path).and_then(|file| file.take(8 * 1024).read_to_end(&mut prefix))
-    {
-        return PreparedEntry {
-            path: path_display,
-            outcome: PreparedOutcome::Message(io_error_message(&path, &error)),
-        };
-    }
-    prepare_classified_entry(
-        entry,
-        collection_budget,
-        &path,
-        path_display,
-        &prefix,
-        PreparedSource::File(&path),
-    )
-}
-
-fn prepare_restricted_entry(
-    entry: &BatchReadEntry,
-    collection_budget: usize,
-    scope: &ReadScope,
-    parsed: &std::path::Path,
-) -> PreparedEntry {
-    let input_display = display_path(parsed);
-    let routed = match scope.route(parsed) {
+    let routed = match scope.route(&parsed) {
         Ok(routed) => routed,
         Err(message) => {
             return PreparedEntry {
@@ -294,7 +216,7 @@ fn prepare_restricted_entry(
         Err(error) => {
             return PreparedEntry {
                 path: input_display,
-                outcome: PreparedOutcome::Message(io_error_message(parsed, &error)),
+                outcome: PreparedOutcome::Message(io_error_message(&parsed, &error)),
             };
         }
     };
@@ -320,7 +242,7 @@ fn prepare_restricted_entry(
         Err(error) => {
             return PreparedEntry {
                 path: path_display,
-                outcome: PreparedOutcome::Message(io_error_message(parsed, &error)),
+                outcome: PreparedOutcome::Message(io_error_message(&parsed, &error)),
             };
         }
     };
@@ -331,7 +253,7 @@ fn prepare_restricted_entry(
         Err(error) => {
             return PreparedEntry {
                 path: path_display,
-                outcome: PreparedOutcome::Message(io_error_message(parsed, &error)),
+                outcome: PreparedOutcome::Message(io_error_message(&parsed, &error)),
             };
         }
     };
@@ -341,7 +263,7 @@ fn prepare_restricted_entry(
         &routed.canonical,
         path_display,
         &prefix,
-        PreparedSource::Handle(&file),
+        &file,
     )
 }
 
@@ -351,7 +273,7 @@ fn prepare_classified_entry(
     path: &std::path::Path,
     path_display: String,
     prefix: &[u8],
-    source: PreparedSource<'_>,
+    file: &fs::File,
 ) -> PreparedEntry {
     if pdf::is_pdf(path, prefix) {
         return PreparedEntry {
@@ -371,27 +293,16 @@ fn prepare_classified_entry(
             ),
         };
     }
-    let read = match source {
-        PreparedSource::File(path) => text_file::read_batch_text_file(
-            path,
-            &path_display,
-            entry.offset,
-            entry.limit,
-            entry.encoding.as_deref(),
-            detect_binary_type(prefix),
-            collection_budget,
-        ),
-        PreparedSource::Handle(file) => text_file::read_batch_text_handle(
-            file,
-            path,
-            &path_display,
-            entry.offset,
-            entry.limit,
-            entry.encoding.as_deref(),
-            detect_binary_type(prefix),
-            collection_budget,
-        ),
-    };
+    let read = text_file::read_batch_text_handle(
+        file,
+        path,
+        &path_display,
+        entry.offset,
+        entry.limit,
+        entry.encoding.as_deref(),
+        detect_binary_type(prefix),
+        collection_budget,
+    );
     PreparedEntry {
         path: path_display,
         outcome: read.map_or_else(PreparedOutcome::Message, PreparedOutcome::Content),

--- a/src/read_tool/batch.rs
+++ b/src/read_tool/batch.rs
@@ -6,7 +6,8 @@ use crate::budget::{READ_TOKEN_BUDGET_ENV, TokenBudget, estimate_tokens, tool_to
 use crate::encoding::canonical_encoding_label;
 use crate::model::ToolResponse;
 use crate::paths::{
-    canonical_existing, display_path, io_error_message, missing_read_file_message, parse_input_path,
+    ReadScope, absolute_path_required_message, canonical_existing, display_path, io_error_message,
+    missing_read_file_message, parse_input_path,
 };
 use serde::Serialize;
 use std::collections::HashSet;
@@ -36,7 +37,7 @@ enum PreparedOutcome {
     Message(String),
 }
 
-pub(super) fn read_text_files(mut request: ReadRequest) -> ToolResponse {
+pub(super) fn read_text_files(mut request: ReadRequest, scope: &ReadScope) -> ToolResponse {
     let entries = request
         .files
         .take()
@@ -69,17 +70,17 @@ pub(super) fn read_text_files(mut request: ReadRequest) -> ToolResponse {
             ));
         }
     }
-    if let Err(error) = validate_entries(&entries) {
+    if let Err(error) = validate_entries(&entries, scope) {
         return ToolResponse::error(error);
     }
     let budget = match tool_token_budget(READ_TOKEN_BUDGET_ENV) {
         Ok(budget) => budget,
         Err(error) => return ToolResponse::error(error),
     };
-    pack_entries(entries, budget)
+    pack_entries(entries, budget, scope)
 }
 
-fn validate_entries(entries: &[BatchReadEntry]) -> Result<(), String> {
+fn validate_entries(entries: &[BatchReadEntry], scope: &ReadScope) -> Result<(), String> {
     let mut seen = HashSet::with_capacity(entries.len());
     for entry in entries {
         if entry.offset == Some(0) {
@@ -94,13 +95,17 @@ fn validate_entries(entries: &[BatchReadEntry]) -> Result<(), String> {
         {
             return Err(rejection.message(""));
         }
-        // A relative entry is an existence problem, not a request-shape one, so it is
-        // reported in its own segment and never discards its neighbors. Keeping it out
-        // of canonicalization also stops it from resolving into a false duplicate.
-        let key_path = if parsed.is_absolute() {
-            canonical_existing(&parsed).unwrap_or(parsed)
-        } else {
+        // Relative restricted entries and denied absolute entries remain inline outcomes;
+        // never canonicalize them during duplicate validation.
+        let key_path = if !parsed.is_absolute() {
             parsed
+        } else if scope.is_restricted() {
+            match scope.authorize(&parsed) {
+                Ok(authorized) => canonical_existing(&authorized).unwrap_or(authorized),
+                Err(_) => parsed,
+            }
+        } else {
+            canonical_existing(&parsed).unwrap_or(parsed)
         };
         let key = display_path(&key_path);
         #[cfg(windows)]
@@ -115,7 +120,11 @@ fn validate_entries(entries: &[BatchReadEntry]) -> Result<(), String> {
     Ok(())
 }
 
-fn pack_entries(entries: Vec<BatchReadEntry>, budget: TokenBudget) -> ToolResponse {
+fn pack_entries(
+    entries: Vec<BatchReadEntry>,
+    budget: TokenBudget,
+    scope: &ReadScope,
+) -> ToolResponse {
     let total = entries.len();
     let mut progress = entries
         .iter()
@@ -125,7 +134,7 @@ fn pack_entries(entries: Vec<BatchReadEntry>, budget: TokenBudget) -> ToolRespon
     let mut segments = Vec::new();
 
     for (index, entry) in entries.iter().enumerate() {
-        let prepared = prepare_entry(entry, budget.value);
+        let prepared = prepare_entry(entry, budget.value, scope);
         match prepared.outcome {
             PreparedOutcome::Message(message) => {
                 let segment = format!("=== {} ===\n{message}", prepared.path);
@@ -171,16 +180,33 @@ fn pack_entries(entries: Vec<BatchReadEntry>, budget: TokenBudget) -> ToolRespon
     ToolResponse::text(render_response(&segments, &progress, total))
 }
 
-fn prepare_entry(entry: &BatchReadEntry, collection_budget: usize) -> PreparedEntry {
+fn prepare_entry(
+    entry: &BatchReadEntry,
+    collection_budget: usize,
+    scope: &ReadScope,
+) -> PreparedEntry {
     let parsed = parse_input_path(&entry.path);
     let input_display = display_path(&parsed);
     if !parsed.is_absolute() {
         return PreparedEntry {
             path: input_display,
-            outcome: PreparedOutcome::Message(missing_read_file_message(&entry.path)),
+            outcome: PreparedOutcome::Message(if scope.is_restricted() {
+                absolute_path_required_message(&entry.path)
+            } else {
+                missing_read_file_message(&entry.path)
+            }),
         };
     }
-    let metadata = match fs::metadata(&parsed) {
+    let authorized = match scope.authorize(&parsed) {
+        Ok(path) => path,
+        Err(message) => {
+            return PreparedEntry {
+                path: input_display,
+                outcome: PreparedOutcome::Message(message),
+            };
+        }
+    };
+    let metadata = match fs::metadata(&authorized) {
         Ok(metadata) => metadata,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             return PreparedEntry {
@@ -191,11 +217,11 @@ fn prepare_entry(entry: &BatchReadEntry, collection_budget: usize) -> PreparedEn
         Err(error) => {
             return PreparedEntry {
                 path: input_display,
-                outcome: PreparedOutcome::Message(io_error_message(&parsed, &error)),
+                outcome: PreparedOutcome::Message(io_error_message(&authorized, &error)),
             };
         }
     };
-    let path = canonical_existing(&parsed).unwrap_or(parsed);
+    let path = canonical_existing(&authorized).unwrap_or(authorized);
     let path_display = display_path(&path);
     if metadata.is_dir() {
         return PreparedEntry {

--- a/src/read_tool/batch.rs
+++ b/src/read_tool/batch.rs
@@ -37,6 +37,12 @@ enum PreparedOutcome {
     Message(String),
 }
 
+#[derive(Clone, Copy)]
+enum PreparedSource<'a> {
+    File(&'a std::path::Path),
+    Handle(&'a fs::File),
+}
+
 pub(super) fn read_text_files(mut request: ReadRequest, scope: &ReadScope) -> ToolResponse {
     let entries = request
         .files
@@ -251,40 +257,14 @@ fn prepare_entry(
             outcome: PreparedOutcome::Message(io_error_message(&path, &error)),
         };
     }
-    if pdf::is_pdf(&path, &prefix) {
-        return PreparedEntry {
-            path: path_display,
-            outcome: PreparedOutcome::Message(
-                "PDF files cannot be included in files. Read this file separately with file_path and optional pages/pdf_mode."
-                    .to_string(),
-            ),
-        };
-    }
-    if image_file::detect_image_mime(&path, &prefix).is_some() {
-        return PreparedEntry {
-            path: path_display,
-            outcome: PreparedOutcome::Message(
-                "Image files cannot be included in files. Read this file separately with file_path."
-                    .to_string(),
-            ),
-        };
-    }
-    let outcome = match text_file::read_batch_text_file(
-        &path,
-        &path_display,
-        entry.offset,
-        entry.limit,
-        entry.encoding.as_deref(),
-        detect_binary_type(&prefix),
+    prepare_classified_entry(
+        entry,
         collection_budget,
-    ) {
-        Ok(content) => PreparedOutcome::Content(content),
-        Err(message) => PreparedOutcome::Message(message),
-    };
-    PreparedEntry {
-        path: path_display,
-        outcome,
-    }
+        &path,
+        path_display,
+        &prefix,
+        PreparedSource::File(&path),
+    )
 }
 
 fn prepare_restricted_entry(
@@ -355,36 +335,66 @@ fn prepare_restricted_entry(
             };
         }
     };
-    if pdf::is_pdf(&routed.canonical, &prefix) {
-        return PreparedEntry {
-            path: path_display,
-            outcome: PreparedOutcome::Message(
-                "PDF files cannot be included in files. Read this file separately with file_path and optional pages/pdf_mode.".to_string(),
-            ),
-        };
-    }
-    if image_file::detect_image_mime(&routed.canonical, &prefix).is_some() {
-        return PreparedEntry {
-            path: path_display,
-            outcome: PreparedOutcome::Message(
-                "Image files cannot be included in files. Read this file separately with file_path.".to_string(),
-            ),
-        };
-    }
-    let outcome = text_file::read_batch_text_handle(
-        &file,
-        &routed.canonical,
-        &path_display,
-        entry.offset,
-        entry.limit,
-        entry.encoding.as_deref(),
-        detect_binary_type(&prefix),
+    prepare_classified_entry(
+        entry,
         collection_budget,
+        &routed.canonical,
+        path_display,
+        &prefix,
+        PreparedSource::Handle(&file),
     )
-    .map_or_else(PreparedOutcome::Message, PreparedOutcome::Content);
+}
+
+fn prepare_classified_entry(
+    entry: &BatchReadEntry,
+    collection_budget: usize,
+    path: &std::path::Path,
+    path_display: String,
+    prefix: &[u8],
+    source: PreparedSource<'_>,
+) -> PreparedEntry {
+    if pdf::is_pdf(path, prefix) {
+        return PreparedEntry {
+            path: path_display,
+            outcome: PreparedOutcome::Message(
+                "PDF files cannot be included in files. Read this file separately with file_path and optional pages/pdf_mode."
+                    .to_string(),
+            ),
+        };
+    }
+    if image_file::detect_image_mime(path, prefix).is_some() {
+        return PreparedEntry {
+            path: path_display,
+            outcome: PreparedOutcome::Message(
+                "Image files cannot be included in files. Read this file separately with file_path."
+                    .to_string(),
+            ),
+        };
+    }
+    let read = match source {
+        PreparedSource::File(path) => text_file::read_batch_text_file(
+            path,
+            &path_display,
+            entry.offset,
+            entry.limit,
+            entry.encoding.as_deref(),
+            detect_binary_type(prefix),
+            collection_budget,
+        ),
+        PreparedSource::Handle(file) => text_file::read_batch_text_handle(
+            file,
+            path,
+            &path_display,
+            entry.offset,
+            entry.limit,
+            entry.encoding.as_deref(),
+            detect_binary_type(prefix),
+            collection_budget,
+        ),
+    };
     PreparedEntry {
         path: path_display,
-        outcome,
+        outcome: read.map_or_else(PreparedOutcome::Message, PreparedOutcome::Content),
     }
 }
 

--- a/src/read_tool/batch.rs
+++ b/src/read_tool/batch.rs
@@ -1,6 +1,6 @@
 //! Request-ordered text batching with one shared token budget and exact continuations.
 
-use super::{BatchReadEntry, ReadRequest, image_file, pdf, text_file};
+use super::{BatchReadEntry, ReadRequest, image_file, pdf, read_prefix, text_file};
 use crate::binary::detect_binary_type;
 use crate::budget::{READ_TOKEN_BUDGET_ENV, TokenBudget, estimate_tokens, tool_token_budget};
 use crate::encoding::canonical_encoding_label;
@@ -197,6 +197,9 @@ fn prepare_entry(
             }),
         };
     }
+    if scope.is_restricted() {
+        return prepare_restricted_entry(entry, collection_budget, scope, &parsed);
+    }
     let authorized = match scope.authorize(&parsed) {
         Ok(path) => path,
         Err(message) => {
@@ -278,6 +281,107 @@ fn prepare_entry(
         Ok(content) => PreparedOutcome::Content(content),
         Err(message) => PreparedOutcome::Message(message),
     };
+    PreparedEntry {
+        path: path_display,
+        outcome,
+    }
+}
+
+fn prepare_restricted_entry(
+    entry: &BatchReadEntry,
+    collection_budget: usize,
+    scope: &ReadScope,
+    parsed: &std::path::Path,
+) -> PreparedEntry {
+    let input_display = display_path(parsed);
+    let routed = match scope.route(parsed) {
+        Ok(routed) => routed,
+        Err(message) => {
+            return PreparedEntry {
+                path: input_display,
+                outcome: PreparedOutcome::Message(message),
+            };
+        }
+    };
+    let metadata = match routed.capability.metadata(&routed.relative) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return PreparedEntry {
+                path: input_display,
+                outcome: PreparedOutcome::Message(missing_read_file_message(&entry.path)),
+            };
+        }
+        Err(error) => {
+            return PreparedEntry {
+                path: input_display,
+                outcome: PreparedOutcome::Message(io_error_message(parsed, &error)),
+            };
+        }
+    };
+    let path_display = routed.display.clone();
+    if metadata.is_dir() {
+        return PreparedEntry {
+            path: path_display.clone(),
+            outcome: PreparedOutcome::Message(format!(
+                "{path_display} is a directory, not a file. Use the glob tool to list its contents."
+            )),
+        };
+    }
+    if !metadata.is_file() {
+        return PreparedEntry {
+            path: path_display.clone(),
+            outcome: PreparedOutcome::Message(format!(
+                "Cannot read non-regular file: {path_display}. Only regular files are supported."
+            )),
+        };
+    }
+    let mut file = match routed.capability.open(&routed.relative) {
+        Ok(file) => file.into_std(),
+        Err(error) => {
+            return PreparedEntry {
+                path: path_display,
+                outcome: PreparedOutcome::Message(io_error_message(parsed, &error)),
+            };
+        }
+    };
+    #[cfg(test)]
+    crate::file_snapshot::tests::notify_original_open(&routed.canonical);
+    let prefix = match read_prefix(&mut file) {
+        Ok(prefix) => prefix,
+        Err(error) => {
+            return PreparedEntry {
+                path: path_display,
+                outcome: PreparedOutcome::Message(io_error_message(parsed, &error)),
+            };
+        }
+    };
+    if pdf::is_pdf(&routed.canonical, &prefix) {
+        return PreparedEntry {
+            path: path_display,
+            outcome: PreparedOutcome::Message(
+                "PDF files cannot be included in files. Read this file separately with file_path and optional pages/pdf_mode.".to_string(),
+            ),
+        };
+    }
+    if image_file::detect_image_mime(&routed.canonical, &prefix).is_some() {
+        return PreparedEntry {
+            path: path_display,
+            outcome: PreparedOutcome::Message(
+                "Image files cannot be included in files. Read this file separately with file_path.".to_string(),
+            ),
+        };
+    }
+    let outcome = text_file::read_batch_text_handle(
+        &file,
+        &routed.canonical,
+        &path_display,
+        entry.offset,
+        entry.limit,
+        entry.encoding.as_deref(),
+        detect_binary_type(&prefix),
+        collection_budget,
+    )
+    .map_or_else(PreparedOutcome::Message, PreparedOutcome::Content);
     PreparedEntry {
         path: path_display,
         outcome,

--- a/src/read_tool/batch.rs
+++ b/src/read_tool/batch.rs
@@ -220,7 +220,7 @@ fn prepare_entry(
             };
         }
     };
-    let path_display = routed.display.clone();
+    let path_display = display_path(&routed.canonical);
     if metadata.is_dir() {
         return PreparedEntry {
             path: path_display.clone(),

--- a/src/read_tool/hex_file.rs
+++ b/src/read_tool/hex_file.rs
@@ -27,7 +27,7 @@ pub(super) fn read_hex_file(
         return ToolResponse::error("Invalid limit value: 0. Expected an integer >= 1.");
     }
 
-    let mut file = match File::open(path) {
+    let file = match File::open(path) {
         Ok(file) => file,
         Err(error) => return ToolResponse::error(io_error_message(path, &error)),
     };
@@ -35,10 +35,44 @@ pub(super) fn read_hex_file(
         Ok(metadata) => metadata.len(),
         Err(error) => return ToolResponse::error(io_error_message(path, &error)),
     };
+    read_hex_reader(file, file_size, path, offset, limit, budget)
+}
+
+pub(super) fn read_hex_handle(
+    file: File,
+    path: &Path,
+    offset: Option<usize>,
+    limit: Option<usize>,
+    budget: TokenBudget,
+) -> ToolResponse {
+    let offset = offset.unwrap_or(1);
+    let limit = limit.unwrap_or(DEFAULT_HEX_LINE_LIMIT);
+    if offset == 0 {
+        return ToolResponse::error("Invalid offset value: 0. Expected an integer >= 1.");
+    }
+    if limit == 0 {
+        return ToolResponse::error("Invalid limit value: 0. Expected an integer >= 1.");
+    }
+    let file_size = match file.metadata() {
+        Ok(metadata) => metadata.len(),
+        Err(error) => return ToolResponse::error(io_error_message(path, &error)),
+    };
+    read_hex_reader(file, file_size, path, offset, limit, budget)
+}
+
+fn read_hex_reader(
+    mut file: impl Read + Seek,
+    file_size: u64,
+    path: &Path,
+    offset: usize,
+    limit: usize,
+    budget: TokenBudget,
+) -> ToolResponse {
     if file_size == 0 {
         return ToolResponse::text("Warning: the file exists but is empty.");
     }
-    let total_lines = file_size / BYTES_PER_LINE + u64::from(file_size % BYTES_PER_LINE != 0);
+    let total_lines =
+        file_size / BYTES_PER_LINE + u64::from(!file_size.is_multiple_of(BYTES_PER_LINE));
     let offset_line = offset as u64;
     if offset_line > total_lines {
         let noun = if total_lines == 1 { "line" } else { "lines" };

--- a/src/read_tool/hex_file.rs
+++ b/src/read_tool/hex_file.rs
@@ -12,32 +12,6 @@ use std::path::Path;
 const BYTES_PER_LINE: u64 = 16;
 const HEX_COLUMN_WIDTH: usize = 48;
 
-pub(super) fn read_hex_file(
-    path: &Path,
-    offset: Option<usize>,
-    limit: Option<usize>,
-    budget: TokenBudget,
-) -> ToolResponse {
-    let offset = offset.unwrap_or(1);
-    let limit = limit.unwrap_or(DEFAULT_HEX_LINE_LIMIT);
-    if offset == 0 {
-        return ToolResponse::error("Invalid offset value: 0. Expected an integer >= 1.");
-    }
-    if limit == 0 {
-        return ToolResponse::error("Invalid limit value: 0. Expected an integer >= 1.");
-    }
-
-    let file = match File::open(path) {
-        Ok(file) => file,
-        Err(error) => return ToolResponse::error(io_error_message(path, &error)),
-    };
-    let file_size = match file.metadata() {
-        Ok(metadata) => metadata.len(),
-        Err(error) => return ToolResponse::error(io_error_message(path, &error)),
-    };
-    read_hex_reader(file, file_size, path, offset, limit, budget)
-}
-
 pub(super) fn read_hex_handle(
     file: File,
     path: &Path,
@@ -176,7 +150,7 @@ fn line_span(first: u64, last: u64) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{format_hex_line, read_hex_file};
+    use super::{format_hex_line, read_hex_handle};
     use crate::ToolContent;
     use crate::budget::TokenBudget;
 
@@ -201,7 +175,8 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("bytes.bin");
         std::fs::write(&path, b"0123456789ABCDEFmore").unwrap();
-        let response = read_hex_file(
+        let response = read_hex_handle(
+            std::fs::File::open(&path).unwrap(),
             &path,
             None,
             None,

--- a/src/read_tool/image_file.rs
+++ b/src/read_tool/image_file.rs
@@ -42,42 +42,11 @@ pub(super) fn detect_image_mime(path: &Path, bytes: &[u8]) -> Option<&'static st
 }
 
 pub(super) fn read_image(path: &Path) -> ToolResponse {
-    let mut file = match File::open(path) {
+    let file = match File::open(path) {
         Ok(file) => file,
         Err(error) => return ToolResponse::error(io_error_message(path, &error)),
     };
-    let reported_size = match file.metadata() {
-        Ok(metadata) => metadata.len(),
-        Err(error) => return ToolResponse::error(io_error_message(path, &error)),
-    };
-    if reported_size > MAX_IMAGE_BYTES as u64 {
-        return oversized_image(reported_size);
-    }
-    let mut bytes = Vec::with_capacity(reported_size as usize);
-    if let Err(error) = file
-        .by_ref()
-        .take(MAX_IMAGE_BYTES as u64 + 1)
-        .read_to_end(&mut bytes)
-    {
-        return ToolResponse::error(io_error_message(path, &error));
-    }
-    if bytes.len() > MAX_IMAGE_BYTES {
-        return oversized_image(bytes.len() as u64);
-    }
-    let Some(mime_type) = detect_image_mime(path, &bytes) else {
-        return ToolResponse::error(format!(
-            "Cannot read image file: {}. Retry after confirming it is a PNG, JPG, GIF, WebP, or BMP file.",
-            crate::paths::display_path(path)
-        ));
-    };
-    ToolResponse {
-        content: vec![ToolContent::Image {
-            data: base64::engine::general_purpose::STANDARD.encode(bytes),
-            mime_type: mime_type.to_string(),
-            detail: None,
-        }],
-        is_error: false,
-    }
+    read_image_handle(file, path)
 }
 
 pub(super) fn read_image_handle(mut file: File, path: &Path) -> ToolResponse {

--- a/src/read_tool/image_file.rs
+++ b/src/read_tool/image_file.rs
@@ -80,6 +80,41 @@ pub(super) fn read_image(path: &Path) -> ToolResponse {
     }
 }
 
+pub(super) fn read_image_handle(mut file: File, path: &Path) -> ToolResponse {
+    let reported_size = match file.metadata() {
+        Ok(metadata) => metadata.len(),
+        Err(error) => return ToolResponse::error(io_error_message(path, &error)),
+    };
+    if reported_size > MAX_IMAGE_BYTES as u64 {
+        return oversized_image(reported_size);
+    }
+    let mut bytes = Vec::with_capacity(reported_size as usize);
+    if let Err(error) = file
+        .by_ref()
+        .take(MAX_IMAGE_BYTES as u64 + 1)
+        .read_to_end(&mut bytes)
+    {
+        return ToolResponse::error(io_error_message(path, &error));
+    }
+    if bytes.len() > MAX_IMAGE_BYTES {
+        return oversized_image(bytes.len() as u64);
+    }
+    let Some(mime_type) = detect_image_mime(path, &bytes) else {
+        return ToolResponse::error(format!(
+            "Cannot read image file: {}. Retry after confirming it is a PNG, JPG, GIF, WebP, or BMP file.",
+            crate::paths::display_path(path)
+        ));
+    };
+    ToolResponse {
+        content: vec![ToolContent::Image {
+            data: base64::engine::general_purpose::STANDARD.encode(bytes),
+            mime_type: mime_type.to_string(),
+            detail: None,
+        }],
+        is_error: false,
+    }
+}
+
 fn oversized_image(size: u64) -> ToolResponse {
     let mib = ((size as f64 / (1024.0 * 1024.0)) * 10.0).ceil() / 10.0;
     ToolResponse::error(format!(

--- a/src/read_tool/image_file.rs
+++ b/src/read_tool/image_file.rs
@@ -41,14 +41,6 @@ pub(super) fn detect_image_mime(path: &Path, bytes: &[u8]) -> Option<&'static st
     }
 }
 
-pub(super) fn read_image(path: &Path) -> ToolResponse {
-    let file = match File::open(path) {
-        Ok(file) => file,
-        Err(error) => return ToolResponse::error(io_error_message(path, &error)),
-    };
-    read_image_handle(file, path)
-}
-
 pub(super) fn read_image_handle(mut file: File, path: &Path) -> ToolResponse {
     let reported_size = match file.metadata() {
         Ok(metadata) => metadata.len(),
@@ -93,7 +85,7 @@ fn oversized_image(size: u64) -> ToolResponse {
 
 #[cfg(test)]
 mod tests {
-    use super::read_image;
+    use super::read_image_handle;
     use crate::ToolContent;
 
     #[test]
@@ -101,7 +93,7 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("changed.bin");
         std::fs::write(&path, b"not an image anymore").unwrap();
-        let response = read_image(&path);
+        let response = read_image_handle(std::fs::File::open(&path).unwrap(), &path);
         assert!(response.is_error);
         assert_eq!(
             response.content,

--- a/src/read_tool/mod.rs
+++ b/src/read_tool/mod.rs
@@ -16,14 +16,13 @@ use crate::binary::detect_binary_type;
 use crate::budget::{READ_TOKEN_BUDGET_ENV, tool_token_budget};
 use crate::model::ToolResponse;
 use crate::paths::{
-    ReadScope, absolute_path_required_message, canonical_existing, display_path, io_error_message,
+    ReadScope, absolute_path_required_message, display_path, io_error_message,
     missing_read_file_message, parse_input_path,
 };
 use schemars::JsonSchema;
 use serde::Deserialize;
 use std::fs;
 use std::io::{Read, Seek, SeekFrom};
-use std::path::Path;
 
 /// Line window for a text read that omits `limit`: unbounded, so the token budget is the only
 /// ceiling on how much one call returns.
@@ -124,140 +123,24 @@ pub(crate) fn read_file_with_scope(request: ReadRequest, scope: &ReadScope) -> T
         }
         return ToolResponse::error(missing_read_file_message(file_path));
     }
-    if scope.is_restricted() {
-        return read_restricted_file(request.clone(), scope, &parsed, file_path);
-    }
-    let authorized = match scope.authorize(&parsed) {
-        Ok(path) => path,
-        Err(message) => return ToolResponse::error(message),
-    };
-    let metadata = match fs::metadata(&authorized) {
-        Ok(metadata) => metadata,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            return ToolResponse::error(missing_read_file_message(file_path));
-        }
-        Err(error) => return ToolResponse::error(io_error_message(&authorized, &error)),
-    };
-    let path = canonical_existing(&authorized).unwrap_or(authorized);
-    let path_display = display_path(&path);
-    if metadata.is_dir() {
-        return ToolResponse::error(format!(
-            "{path_display} is a directory, not a file. Use the glob tool to list its contents."
-        ));
-    }
-    if !metadata.is_file() {
-        return ToolResponse::error(format!(
-            "Cannot read non-regular file: {path_display}. Only regular files are supported."
-        ));
-    }
-    let mut prefix = Vec::new();
-    let prefix_result =
-        fs::File::open(&path).and_then(|file| file.take(8 * 1024).read_to_end(&mut prefix));
-    if let Err(error) = prefix_result {
-        return ToolResponse::error(io_error_message(&path, &error));
-    }
-
-    let view = match parse_view(request.view.as_deref()) {
-        Ok(view) => view,
-        Err(message) => return ToolResponse::error(message),
-    };
-    if view == ViewMode::Hex {
-        for (parameter, present) in [
-            ("pdf_mode", request.pdf_mode.is_some()),
-            ("pages", request.pages.is_some()),
-            ("encoding", request.encoding.is_some()),
-        ] {
-            if present {
-                return ToolResponse::error(format!(
-                    "The {parameter} parameter cannot be combined with view=\"hex\"."
-                ));
-            }
-        }
-        let budget = match tool_token_budget(READ_TOKEN_BUDGET_ENV) {
-            Ok(budget) => budget,
+    let view = if scope.is_restricted() {
+        match validate_view_parameters(&request) {
+            Ok(view) => Some(view),
             Err(message) => return ToolResponse::error(message),
-        };
-        return hex_file::read_hex_file(&path, request.offset, request.limit, budget);
-    }
-
-    if pdf::is_pdf(&path, &prefix) {
-        if request.encoding.is_some() {
-            return ToolResponse::error("The encoding parameter only applies to text files.");
         }
-        let mode = match pdf::parse_pdf_mode(request.pdf_mode.as_deref()) {
-            Ok(mode) => mode,
-            Err(message) => return ToolResponse::error(message),
-        };
-        let budget = if mode == pdf::PdfMode::Text {
-            match tool_token_budget(READ_TOKEN_BUDGET_ENV) {
-                Ok(budget) => Some(budget),
-                Err(message) => return ToolResponse::error(message),
-            }
-        } else {
-            None
-        };
-        return pdf::read_pdf(&path, request.pages.as_deref(), mode, budget);
-    }
-    if request.pages.is_some() {
-        return ToolResponse::error("The pages parameter only applies to PDF files.");
-    }
-    if request.pdf_mode.is_some() {
-        return ToolResponse::error("The pdf_mode parameter only applies to PDF files.");
-    }
-    if image_file::detect_image_mime(&path, &prefix).is_some() {
-        if request.encoding.is_some() {
-            return ToolResponse::error("The encoding parameter only applies to text files.");
-        }
-        return image_file::read_image(&path);
-    }
-    let budget = match tool_token_budget(READ_TOKEN_BUDGET_ENV) {
-        Ok(budget) => budget,
-        Err(message) => return ToolResponse::error(message),
+    } else {
+        None
     };
-    text_file::read_text_file(
-        &path,
-        &path_display,
-        request.offset,
-        request.limit,
-        request.encoding.as_deref(),
-        detect_binary_type(&prefix),
-        budget,
-    )
-}
-
-fn read_restricted_file(
-    request: ReadRequest,
-    scope: &ReadScope,
-    parsed: &Path,
-    original: &str,
-) -> ToolResponse {
-    let view = match parse_view(request.view.as_deref()) {
-        Ok(view) => view,
-        Err(message) => return ToolResponse::error(message),
-    };
-    if view == ViewMode::Hex {
-        for (parameter, present) in [
-            ("pdf_mode", request.pdf_mode.is_some()),
-            ("pages", request.pages.is_some()),
-            ("encoding", request.encoding.is_some()),
-        ] {
-            if present {
-                return ToolResponse::error(format!(
-                    "The {parameter} parameter cannot be combined with view=\"hex\"."
-                ));
-            }
-        }
-    }
-    let routed = match scope.route(parsed) {
+    let routed = match scope.route(&parsed) {
         Ok(routed) => routed,
         Err(message) => return ToolResponse::error(message),
     };
     let metadata = match routed.capability.metadata(&routed.relative) {
         Ok(metadata) => metadata,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            return ToolResponse::error(missing_read_file_message(original));
+            return ToolResponse::error(missing_read_file_message(file_path));
         }
-        Err(error) => return ToolResponse::error(io_error_message(parsed, &error)),
+        Err(error) => return ToolResponse::error(io_error_message(&parsed, &error)),
     };
     if metadata.is_dir() {
         return ToolResponse::error(format!(
@@ -273,15 +156,22 @@ fn read_restricted_file(
     }
     let mut file = match routed.capability.open(&routed.relative) {
         Ok(file) => file.into_std(),
-        Err(error) => return ToolResponse::error(io_error_message(parsed, &error)),
+        Err(error) => return ToolResponse::error(io_error_message(&parsed, &error)),
     };
     #[cfg(test)]
     crate::file_snapshot::tests::notify_original_open(&routed.canonical);
     let prefix = match read_prefix(&mut file) {
         Ok(prefix) => prefix,
         Err(error) => {
-            return ToolResponse::error(io_error_message(parsed, &error));
+            return ToolResponse::error(io_error_message(&parsed, &error));
         }
+    };
+    let view = match view {
+        Some(view) => view,
+        None => match validate_view_parameters(&request) {
+            Ok(view) => view,
+            Err(message) => return ToolResponse::error(message),
+        },
     };
     if view == ViewMode::Hex {
         let budget = match tool_token_budget(READ_TOKEN_BUDGET_ENV) {
@@ -366,6 +256,24 @@ fn parse_view(value: Option<&str>) -> Result<ViewMode, String> {
     }
 }
 
+fn validate_view_parameters(request: &ReadRequest) -> Result<ViewMode, String> {
+    let view = parse_view(request.view.as_deref())?;
+    if view == ViewMode::Hex {
+        for (parameter, present) in [
+            ("pdf_mode", request.pdf_mode.is_some()),
+            ("pages", request.pages.is_some()),
+            ("encoding", request.encoding.is_some()),
+        ] {
+            if present {
+                return Err(format!(
+                    "The {parameter} parameter cannot be combined with view=\"hex\"."
+                ));
+            }
+        }
+    }
+    Ok(view)
+}
+
 fn binary_error(path_display: &str, binary_type: Option<&str>) -> ToolResponse {
     ToolResponse::error(binary_error_message(path_display, binary_type))
 }
@@ -381,7 +289,7 @@ fn binary_error_message(path_display: &str, binary_type: Option<&str>) -> String
 mod tests {
     use super::{BatchReadEntry, ReadRequest, read_file, read_file_with_scope};
     use crate::ToolContent;
-    use crate::paths::{ReadScope, display_path};
+    use crate::paths::{ReadScope, display_path, missing_read_file_message};
     use std::fs;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -404,6 +312,38 @@ mod tests {
             panic!("expected one text response: {response:?}");
         };
         text.clone()
+    }
+
+    #[test]
+    fn unrestricted_missing_parent_keeps_missing_diagnostics_before_view_validation() {
+        let fixture = tempfile::tempdir().unwrap();
+        let path = fixture.path().join("missing-parent").join("input.txt");
+        let path_display = display_path(&path);
+        let expected = missing_read_file_message(&path_display);
+
+        let mut request = single(&path);
+        request.view = Some("invalid".to_string());
+        assert_eq!(response_text(read_file(request)), expected);
+
+        let batch = ReadRequest {
+            file_path: None,
+            files: Some(vec![BatchReadEntry {
+                path: path_display,
+                offset: None,
+                limit: None,
+                encoding: None,
+            }]),
+            offset: None,
+            limit: None,
+            pages: None,
+            pdf_mode: None,
+            encoding: None,
+            view: None,
+        };
+        assert!(
+            response_text(read_file(batch)).contains(&expected),
+            "batch missing-parent diagnostics changed"
+        );
     }
 
     #[test]
@@ -722,133 +662,179 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn restricted_direct_read_pins_open_handle_before_final_component_swap() {
-        let fixture = tempfile::tempdir().unwrap();
-        let root = fixture.path().join("allowed");
-        fs::create_dir(&root).unwrap();
-        let path = root.join("inside.txt");
-        let old_path = root.join("inside.old");
-        fs::write(&path, b"original-inside-bytes").unwrap();
-        let path_for_hook = path.clone();
-        let old_for_hook = old_path.clone();
-        let _hook =
-            crate::file_snapshot::tests::OriginalOpenObserverGuard::install(Arc::new(move |_| {
-                if path_for_hook.exists() {
-                    fs::rename(&path_for_hook, &old_for_hook).unwrap();
-                    fs::write(&path_for_hook, b"replacement-outside-bytes").unwrap();
-                }
-            }));
-        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
-        let response = read_file_with_scope(single(&path), &scope);
-        let text = response_text(response);
-        assert!(text.contains("original-inside-bytes"), "{text}");
-        assert!(!text.contains("replacement-outside-bytes"), "{text}");
+    fn direct_read_pins_open_handle_before_final_component_swap_in_both_modes() {
+        for restricted in [false, true] {
+            let fixture = tempfile::tempdir().unwrap();
+            let root = fixture.path().join("allowed");
+            fs::create_dir(&root).unwrap();
+            let path = root.join("inside.txt");
+            let old_path = root.join("inside.old");
+            fs::write(&path, b"original-inside-bytes").unwrap();
+            let path_for_hook = path.clone();
+            let old_for_hook = old_path.clone();
+            let _hook = crate::file_snapshot::tests::OriginalOpenObserverGuard::install(Arc::new(
+                move |_| {
+                    if path_for_hook.exists() {
+                        fs::rename(&path_for_hook, &old_for_hook).unwrap();
+                        fs::write(&path_for_hook, b"replacement-outside-bytes").unwrap();
+                    }
+                },
+            ));
+            let scope = if restricted {
+                ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap()
+            } else {
+                ReadScope::unrestricted()
+            };
+            let response = read_file_with_scope(single(&path), &scope);
+            let text = response_text(response);
+            assert!(
+                text.contains("original-inside-bytes"),
+                "{restricted}: {text}"
+            );
+            assert!(
+                !text.contains("replacement-outside-bytes"),
+                "{restricted}: {text}"
+            );
+        }
     }
 
     #[cfg(windows)]
     #[test]
-    fn restricted_direct_read_pins_open_handle_before_windows_rename_swap() {
+    fn direct_read_pins_open_handle_before_windows_rename_swap_in_both_modes() {
         use std::sync::atomic::{AtomicBool, Ordering};
 
-        let fixture = tempfile::tempdir().unwrap();
-        let root = fixture.path().join("allowed");
-        fs::create_dir(&root).unwrap();
-        let path = root.join("inside.txt");
-        let old_path = root.join("inside.old");
-        fs::write(&path, b"original-windows-bytes").unwrap();
-        let renamed = Arc::new(AtomicBool::new(false));
-        let renamed_for_hook = Arc::clone(&renamed);
-        let path_for_hook = path.clone();
-        let old_for_hook = old_path.clone();
-        let _hook =
-            crate::file_snapshot::tests::OriginalOpenObserverGuard::install(Arc::new(move |_| {
-                if !renamed_for_hook.swap(true, Ordering::AcqRel) {
-                    fs::rename(&path_for_hook, &old_for_hook)
-                        .expect("capability handle must allow a share-delete rename");
-                    fs::write(&path_for_hook, b"replacement-windows-bytes").unwrap();
-                }
-            }));
-        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
-        let text = response_text(read_file_with_scope(single(&path), &scope));
-        assert!(renamed.load(Ordering::Acquire));
-        assert!(text.contains("original-windows-bytes"), "{text}");
-        assert!(!text.contains("replacement-windows-bytes"), "{text}");
+        for restricted in [false, true] {
+            let fixture = tempfile::tempdir().unwrap();
+            let root = fixture.path().join("allowed");
+            fs::create_dir(&root).unwrap();
+            let path = root.join("inside.txt");
+            let old_path = root.join("inside.old");
+            fs::write(&path, b"original-windows-bytes").unwrap();
+            let renamed = Arc::new(AtomicBool::new(false));
+            let renamed_for_hook = Arc::clone(&renamed);
+            let path_for_hook = path.clone();
+            let old_for_hook = old_path.clone();
+            let _hook = crate::file_snapshot::tests::OriginalOpenObserverGuard::install(Arc::new(
+                move |_| {
+                    if !renamed_for_hook.swap(true, Ordering::AcqRel) {
+                        fs::rename(&path_for_hook, &old_for_hook)
+                            .expect("capability handle must allow a share-delete rename");
+                        fs::write(&path_for_hook, b"replacement-windows-bytes").unwrap();
+                    }
+                },
+            ));
+            let scope = if restricted {
+                ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap()
+            } else {
+                ReadScope::unrestricted()
+            };
+            let text = response_text(read_file_with_scope(single(&path), &scope));
+            assert!(renamed.load(Ordering::Acquire));
+            assert!(
+                text.contains("original-windows-bytes"),
+                "{restricted}: {text}"
+            );
+            assert!(
+                !text.contains("replacement-windows-bytes"),
+                "{restricted}: {text}"
+            );
+        }
     }
 
     #[cfg(unix)]
     #[test]
-    fn restricted_batch_pins_open_handle_for_swapped_entry_and_keeps_neighbor() {
-        let fixture = tempfile::tempdir().unwrap();
-        let root = fixture.path().join("allowed");
-        fs::create_dir(&root).unwrap();
-        let first = root.join("first.txt");
-        let second = root.join("second.txt");
-        let old = root.join("first.old");
-        fs::write(&first, b"original-first").unwrap();
-        fs::write(&second, b"stable-second").unwrap();
-        let first_for_hook = first.clone();
-        let old_for_hook = old.clone();
-        let _hook = crate::file_snapshot::tests::OriginalOpenObserverGuard::install(Arc::new(
-            move |path| {
-                if path == first_for_hook && first_for_hook.exists() {
-                    fs::rename(&first_for_hook, &old_for_hook).unwrap();
-                    fs::write(&first_for_hook, b"replacement-first").unwrap();
-                }
-            },
-        ));
-        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
-        let request = ReadRequest {
-            file_path: None,
-            files: Some(vec![
-                BatchReadEntry {
-                    path: display_path(&first),
-                    offset: None,
-                    limit: None,
-                    encoding: None,
+    fn batch_pins_open_handle_for_swapped_entry_in_both_modes_and_keeps_neighbor() {
+        for restricted in [false, true] {
+            let fixture = tempfile::tempdir().unwrap();
+            let root = fixture.path().join("allowed");
+            fs::create_dir(&root).unwrap();
+            let first = root.join("first.txt");
+            let second = root.join("second.txt");
+            let old = root.join("first.old");
+            fs::write(&first, b"original-first").unwrap();
+            fs::write(&second, b"stable-second").unwrap();
+            let first_for_hook = first.clone();
+            let old_for_hook = old.clone();
+            let _hook = crate::file_snapshot::tests::OriginalOpenObserverGuard::install(Arc::new(
+                move |path| {
+                    if path == first_for_hook && first_for_hook.exists() {
+                        fs::rename(&first_for_hook, &old_for_hook).unwrap();
+                        fs::write(&first_for_hook, b"replacement-first").unwrap();
+                    }
                 },
-                BatchReadEntry {
-                    path: display_path(&second),
-                    offset: None,
-                    limit: None,
-                    encoding: None,
-                },
-            ]),
-            offset: None,
-            limit: None,
-            pages: None,
-            pdf_mode: None,
-            encoding: None,
-            view: None,
-        };
-        let text = response_text(read_file_with_scope(request, &scope));
-        assert!(text.contains("original-first"), "{text}");
-        assert!(text.contains("stable-second"), "{text}");
-        assert!(!text.contains("replacement-first"), "{text}");
+            ));
+            let scope = if restricted {
+                ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap()
+            } else {
+                ReadScope::unrestricted()
+            };
+            let request = ReadRequest {
+                file_path: None,
+                files: Some(vec![
+                    BatchReadEntry {
+                        path: display_path(&first),
+                        offset: None,
+                        limit: None,
+                        encoding: None,
+                    },
+                    BatchReadEntry {
+                        path: display_path(&second),
+                        offset: None,
+                        limit: None,
+                        encoding: None,
+                    },
+                ]),
+                offset: None,
+                limit: None,
+                pages: None,
+                pdf_mode: None,
+                encoding: None,
+                view: None,
+            };
+            let text = response_text(read_file_with_scope(request, &scope));
+            assert!(text.contains("original-first"), "{restricted}: {text}");
+            assert!(text.contains("stable-second"), "{restricted}: {text}");
+            assert!(!text.contains("replacement-first"), "{restricted}: {text}");
+        }
     }
 
     #[cfg(unix)]
     #[test]
-    fn restricted_direct_read_pins_open_handle_before_ancestor_swap() {
-        let fixture = tempfile::tempdir().unwrap();
-        let root = fixture.path().join("allowed");
-        let moved = fixture.path().join("allowed.old");
-        fs::create_dir(&root).unwrap();
-        let path = root.join("inside.txt");
-        fs::write(&path, b"original-ancestor-bytes").unwrap();
-        let root_for_hook = root.clone();
-        let moved_for_hook = moved.clone();
-        let _hook =
-            crate::file_snapshot::tests::OriginalOpenObserverGuard::install(Arc::new(move |_| {
-                if root_for_hook.exists() {
-                    fs::rename(&root_for_hook, &moved_for_hook).unwrap();
-                    fs::create_dir(&root_for_hook).unwrap();
-                    fs::write(root_for_hook.join("inside.txt"), b"replacement-ancestor").unwrap();
-                }
-            }));
-        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
-        let text = response_text(read_file_with_scope(single(&path), &scope));
-        assert!(text.contains("original-ancestor-bytes"), "{text}");
-        assert!(!text.contains("replacement-ancestor"), "{text}");
+    fn direct_read_pins_open_handle_before_ancestor_swap_in_both_modes() {
+        for restricted in [false, true] {
+            let fixture = tempfile::tempdir().unwrap();
+            let root = fixture.path().join("allowed");
+            let moved = fixture.path().join("allowed.old");
+            fs::create_dir(&root).unwrap();
+            let path = root.join("inside.txt");
+            fs::write(&path, b"original-ancestor-bytes").unwrap();
+            let root_for_hook = root.clone();
+            let moved_for_hook = moved.clone();
+            let _hook = crate::file_snapshot::tests::OriginalOpenObserverGuard::install(Arc::new(
+                move |_| {
+                    if root_for_hook.exists() {
+                        fs::rename(&root_for_hook, &moved_for_hook).unwrap();
+                        fs::create_dir(&root_for_hook).unwrap();
+                        fs::write(root_for_hook.join("inside.txt"), b"replacement-ancestor")
+                            .unwrap();
+                    }
+                },
+            ));
+            let scope = if restricted {
+                ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap()
+            } else {
+                ReadScope::unrestricted()
+            };
+            let text = response_text(read_file_with_scope(single(&path), &scope));
+            assert!(
+                text.contains("original-ancestor-bytes"),
+                "{restricted}: {text}"
+            );
+            assert!(
+                !text.contains("replacement-ancestor"),
+                "{restricted}: {text}"
+            );
+        }
     }
 
     #[test]

--- a/src/read_tool/mod.rs
+++ b/src/read_tool/mod.rs
@@ -229,7 +229,7 @@ pub(crate) fn read_file_with_scope(request: ReadRequest, scope: &ReadScope) -> T
     text_file::read_text_handle(
         &file,
         &routed.canonical,
-        &routed.display,
+        &display_path(&routed.canonical),
         request.offset,
         request.limit,
         request.encoding.as_deref(),
@@ -295,8 +295,12 @@ mod tests {
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     fn single(path: &std::path::Path) -> ReadRequest {
+        single_input(display_path(path))
+    }
+
+    fn single_input(path: String) -> ReadRequest {
         ReadRequest {
-            file_path: Some(display_path(path)),
+            file_path: Some(path),
             files: None,
             offset: None,
             limit: None,
@@ -305,6 +309,56 @@ mod tests {
             encoding: None,
             view: None,
         }
+    }
+
+    fn batch_entry(path: String) -> BatchReadEntry {
+        BatchReadEntry {
+            path,
+            offset: None,
+            limit: None,
+            encoding: None,
+        }
+    }
+
+    fn text_entry(path: &std::path::Path) -> BatchReadEntry {
+        batch_entry(display_path(path))
+    }
+
+    fn batch(entries: impl IntoIterator<Item = BatchReadEntry>) -> ReadRequest {
+        ReadRequest {
+            file_path: None,
+            files: Some(entries.into_iter().collect()),
+            offset: None,
+            limit: None,
+            pages: None,
+            pdf_mode: None,
+            encoding: None,
+            view: None,
+        }
+    }
+
+    fn scope_for(root: &std::path::Path, restricted: bool) -> ReadScope {
+        if restricted {
+            ReadScope::from_allow_roots(&[root.to_path_buf()]).unwrap()
+        } else {
+            ReadScope::unrestricted()
+        }
+    }
+
+    #[cfg(unix)]
+    fn replace_file_after_open(
+        path: &std::path::Path,
+        old_path: &std::path::Path,
+        replacement: &'static [u8],
+    ) -> crate::file_snapshot::tests::OriginalOpenObserverGuard {
+        let path = path.to_path_buf();
+        let old_path = old_path.to_path_buf();
+        crate::file_snapshot::tests::OriginalOpenObserverGuard::install(Arc::new(move |opened| {
+            if opened == path && path.exists() {
+                fs::rename(&path, &old_path).unwrap();
+                fs::write(&path, replacement).unwrap();
+            }
+        }))
     }
 
     fn response_text(response: crate::ToolResponse) -> String {
@@ -325,21 +379,7 @@ mod tests {
         request.view = Some("invalid".to_string());
         assert_eq!(response_text(read_file(request)), expected);
 
-        let batch = ReadRequest {
-            file_path: None,
-            files: Some(vec![BatchReadEntry {
-                path: path_display,
-                offset: None,
-                limit: None,
-                encoding: None,
-            }]),
-            offset: None,
-            limit: None,
-            pages: None,
-            pdf_mode: None,
-            encoding: None,
-            view: None,
-        };
+        let batch = batch([batch_entry(path_display)]);
         assert!(
             response_text(read_file(batch)).contains(&expected),
             "batch missing-parent diagnostics changed"
@@ -451,29 +491,10 @@ mod tests {
         let second = root.join("second.txt");
         fs::write(&first, b"first\nsecond\n").unwrap();
         fs::write(&second, b"third\nfourth\n").unwrap();
-        let request = ReadRequest {
-            file_path: None,
-            files: Some(vec![
-                BatchReadEntry {
-                    path: display_path(&first),
-                    offset: Some(2),
-                    limit: Some(1),
-                    encoding: None,
-                },
-                BatchReadEntry {
-                    path: display_path(&second),
-                    offset: None,
-                    limit: None,
-                    encoding: None,
-                },
-            ]),
-            offset: None,
-            limit: None,
-            pages: None,
-            pdf_mode: None,
-            encoding: None,
-            view: None,
-        };
+        let mut first_entry = text_entry(&first);
+        first_entry.offset = Some(2);
+        first_entry.limit = Some(1);
+        let request = batch([first_entry, text_entry(&second)]);
         let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
         assert_eq!(
             response_text(read_file_with_scope(request.clone(), &scope)),
@@ -499,21 +520,7 @@ mod tests {
             response_text(read_file_with_scope(single(&alias), &scope)),
             response_text(read_file(single(&alias)))
         );
-        let batch = ReadRequest {
-            file_path: None,
-            files: Some(vec![BatchReadEntry {
-                path: display_path(&alias),
-                offset: None,
-                limit: None,
-                encoding: None,
-            }]),
-            offset: None,
-            limit: None,
-            pages: None,
-            pdf_mode: None,
-            encoding: None,
-            view: None,
-        };
+        let batch = batch([text_entry(&alias)]);
         assert_eq!(
             response_text(read_file_with_scope(batch.clone(), &scope)),
             response_text(read_file(batch))
@@ -575,48 +582,19 @@ mod tests {
     }
 
     #[test]
-    fn scoped_read_allows_direct_files_and_denies_outside_and_lexical_prefixes() {
+    fn scoped_read_denies_outside_file() {
         let fixture = tempfile::tempdir().unwrap();
         let root = fixture.path().join("work");
-        let sibling = fixture.path().join("work-secret");
+        let outside = fixture.path().join("outside.txt");
         fs::create_dir(&root).unwrap();
-        fs::create_dir(&sibling).unwrap();
-        let inside = root.join("inside.txt");
-        let outside = sibling.join("outside.txt");
-        fs::write(&inside, b"allowed-content").unwrap();
         fs::write(&outside, b"denied-content").unwrap();
         let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
 
-        let allowed = read_file_with_scope(single(&inside), &scope);
-        assert!(!allowed.is_error, "{allowed:?}");
-        assert!(response_text(allowed).contains("allowed-content"));
-
-        for denied_path in [&outside, &sibling.join("outside.txt")] {
-            let response = read_file_with_scope(single(denied_path), &scope);
-            assert!(response.is_error, "{response:?}");
-            let text = response_text(response);
-            assert!(text.starts_with("Permission denied: "), "{text}");
-            assert!(!text.contains("denied-content"), "{text}");
-        }
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn scoped_read_denies_static_file_symlink_without_opening_target() {
-        let fixture = tempfile::tempdir().unwrap();
-        let root = fixture.path().join("allowed");
-        let outside = fixture.path().join("outside.txt");
-        fs::create_dir(&root).unwrap();
-        fs::write(&outside, b"secret-target-content").unwrap();
-        let link = root.join("outside-link.txt");
-        std::os::unix::fs::symlink(&outside, &link).unwrap();
-        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
-
-        let response = read_file_with_scope(single(&link), &scope);
+        let response = read_file_with_scope(single(&outside), &scope);
         assert!(response.is_error, "{response:?}");
         let text = response_text(response);
         assert!(text.starts_with("Permission denied: "), "{text}");
-        assert!(!text.contains("secret-target-content"), "{text}");
+        assert!(!text.contains("denied-content"), "{text}");
     }
 
     #[test]
@@ -629,29 +607,7 @@ mod tests {
         fs::write(&inside, b"allowed-batch-content").unwrap();
         fs::write(&outside, b"denied-batch-content").unwrap();
         let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
-        let request = ReadRequest {
-            file_path: None,
-            files: Some(vec![
-                BatchReadEntry {
-                    path: display_path(&inside),
-                    offset: None,
-                    limit: None,
-                    encoding: None,
-                },
-                BatchReadEntry {
-                    path: display_path(&outside),
-                    offset: None,
-                    limit: None,
-                    encoding: None,
-                },
-            ]),
-            offset: None,
-            limit: None,
-            pages: None,
-            pdf_mode: None,
-            encoding: None,
-            view: None,
-        };
+        let request = batch([text_entry(&inside), text_entry(&outside)]);
         let response = read_file_with_scope(request, &scope);
         assert!(!response.is_error, "{response:?}");
         let text = response_text(response);
@@ -670,21 +626,8 @@ mod tests {
             let path = root.join("inside.txt");
             let old_path = root.join("inside.old");
             fs::write(&path, b"original-inside-bytes").unwrap();
-            let path_for_hook = path.clone();
-            let old_for_hook = old_path.clone();
-            let _hook = crate::file_snapshot::tests::OriginalOpenObserverGuard::install(Arc::new(
-                move |_| {
-                    if path_for_hook.exists() {
-                        fs::rename(&path_for_hook, &old_for_hook).unwrap();
-                        fs::write(&path_for_hook, b"replacement-outside-bytes").unwrap();
-                    }
-                },
-            ));
-            let scope = if restricted {
-                ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap()
-            } else {
-                ReadScope::unrestricted()
-            };
+            let _hook = replace_file_after_open(&path, &old_path, b"replacement-outside-bytes");
+            let scope = scope_for(&root, restricted);
             let response = read_file_with_scope(single(&path), &scope);
             let text = response_text(response);
             assert!(
@@ -723,11 +666,7 @@ mod tests {
                     }
                 },
             ));
-            let scope = if restricted {
-                ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap()
-            } else {
-                ReadScope::unrestricted()
-            };
+            let scope = scope_for(&root, restricted);
             let text = response_text(read_file_with_scope(single(&path), &scope));
             assert!(renamed.load(Ordering::Acquire));
             assert!(
@@ -753,44 +692,9 @@ mod tests {
             let old = root.join("first.old");
             fs::write(&first, b"original-first").unwrap();
             fs::write(&second, b"stable-second").unwrap();
-            let first_for_hook = first.clone();
-            let old_for_hook = old.clone();
-            let _hook = crate::file_snapshot::tests::OriginalOpenObserverGuard::install(Arc::new(
-                move |path| {
-                    if path == first_for_hook && first_for_hook.exists() {
-                        fs::rename(&first_for_hook, &old_for_hook).unwrap();
-                        fs::write(&first_for_hook, b"replacement-first").unwrap();
-                    }
-                },
-            ));
-            let scope = if restricted {
-                ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap()
-            } else {
-                ReadScope::unrestricted()
-            };
-            let request = ReadRequest {
-                file_path: None,
-                files: Some(vec![
-                    BatchReadEntry {
-                        path: display_path(&first),
-                        offset: None,
-                        limit: None,
-                        encoding: None,
-                    },
-                    BatchReadEntry {
-                        path: display_path(&second),
-                        offset: None,
-                        limit: None,
-                        encoding: None,
-                    },
-                ]),
-                offset: None,
-                limit: None,
-                pages: None,
-                pdf_mode: None,
-                encoding: None,
-                view: None,
-            };
+            let _hook = replace_file_after_open(&first, &old, b"replacement-first");
+            let scope = scope_for(&root, restricted);
+            let request = batch([text_entry(&first), text_entry(&second)]);
             let text = response_text(read_file_with_scope(request, &scope));
             assert!(text.contains("original-first"), "{restricted}: {text}");
             assert!(text.contains("stable-second"), "{restricted}: {text}");
@@ -820,11 +724,7 @@ mod tests {
                     }
                 },
             ));
-            let scope = if restricted {
-                ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap()
-            } else {
-                ReadScope::unrestricted()
-            };
+            let scope = scope_for(&root, restricted);
             let text = response_text(read_file_with_scope(single(&path), &scope));
             assert!(
                 text.contains("original-ancestor-bytes"),
@@ -841,42 +741,15 @@ mod tests {
     fn restricted_relative_single_and_batch_requests_use_stable_absolute_errors() {
         let fixture = tempfile::tempdir().unwrap();
         let scope = ReadScope::from_allow_roots(&[fixture.path().to_path_buf()]).unwrap();
-        let single_response = read_file_with_scope(
-            ReadRequest {
-                file_path: Some("relative.txt".to_string()),
-                files: None,
-                offset: None,
-                limit: None,
-                pages: None,
-                pdf_mode: None,
-                encoding: None,
-                view: None,
-            },
-            &scope,
-        );
+        let single_response =
+            read_file_with_scope(single_input("relative.txt".to_string()), &scope);
         assert_eq!(
             response_text(single_response),
             "Path must be absolute: relative.txt"
         );
 
-        let batch_response = read_file_with_scope(
-            ReadRequest {
-                file_path: None,
-                files: Some(vec![BatchReadEntry {
-                    path: "relative.txt".to_string(),
-                    offset: None,
-                    limit: None,
-                    encoding: None,
-                }]),
-                offset: None,
-                limit: None,
-                pages: None,
-                pdf_mode: None,
-                encoding: None,
-                view: None,
-            },
-            &scope,
-        );
+        let batch_response =
+            read_file_with_scope(batch([batch_entry("relative.txt".to_string())]), &scope);
         let text = response_text(batch_response);
         assert!(
             text.contains("Path must be absolute: relative.txt"),
@@ -894,29 +767,7 @@ mod tests {
         fs::write(&outside, b"must-not-leak").unwrap();
         let alias = root.join("..").join("outside.txt");
         let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
-        let request = ReadRequest {
-            file_path: None,
-            files: Some(vec![
-                BatchReadEntry {
-                    path: display_path(&outside),
-                    offset: None,
-                    limit: None,
-                    encoding: None,
-                },
-                BatchReadEntry {
-                    path: display_path(&alias),
-                    offset: None,
-                    limit: None,
-                    encoding: None,
-                },
-            ]),
-            offset: None,
-            limit: None,
-            pages: None,
-            pdf_mode: None,
-            encoding: None,
-            view: None,
-        };
+        let request = batch([text_entry(&outside), text_entry(&alias)]);
         let response = read_file_with_scope(request, &scope);
         assert!(!response.is_error, "{response:?}");
         let text = response_text(response);

--- a/src/read_tool/mod.rs
+++ b/src/read_tool/mod.rs
@@ -22,7 +22,8 @@ use crate::paths::{
 use schemars::JsonSchema;
 use serde::Deserialize;
 use std::fs;
-use std::io::Read;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::Path;
 
 /// Line window for a text read that omits `limit`: unbounded, so the token budget is the only
 /// ceiling on how much one call returns.
@@ -123,6 +124,9 @@ pub(crate) fn read_file_with_scope(request: ReadRequest, scope: &ReadScope) -> T
         }
         return ToolResponse::error(missing_read_file_message(file_path));
     }
+    if scope.is_restricted() {
+        return read_restricted_file(request.clone(), scope, &parsed, file_path);
+    }
     let authorized = match scope.authorize(&parsed) {
         Ok(path) => path,
         Err(message) => return ToolResponse::error(message),
@@ -221,6 +225,137 @@ pub(crate) fn read_file_with_scope(request: ReadRequest, scope: &ReadScope) -> T
     )
 }
 
+fn read_restricted_file(
+    request: ReadRequest,
+    scope: &ReadScope,
+    parsed: &Path,
+    original: &str,
+) -> ToolResponse {
+    let view = match parse_view(request.view.as_deref()) {
+        Ok(view) => view,
+        Err(message) => return ToolResponse::error(message),
+    };
+    if view == ViewMode::Hex {
+        for (parameter, present) in [
+            ("pdf_mode", request.pdf_mode.is_some()),
+            ("pages", request.pages.is_some()),
+            ("encoding", request.encoding.is_some()),
+        ] {
+            if present {
+                return ToolResponse::error(format!(
+                    "The {parameter} parameter cannot be combined with view=\"hex\"."
+                ));
+            }
+        }
+    }
+    let routed = match scope.route(parsed) {
+        Ok(routed) => routed,
+        Err(message) => return ToolResponse::error(message),
+    };
+    let metadata = match routed.capability.metadata(&routed.relative) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return ToolResponse::error(missing_read_file_message(original));
+        }
+        Err(error) => return ToolResponse::error(io_error_message(parsed, &error)),
+    };
+    if metadata.is_dir() {
+        return ToolResponse::error(format!(
+            "{} is a directory, not a file. Use the glob tool to list its contents.",
+            display_path(&routed.canonical)
+        ));
+    }
+    if !metadata.is_file() {
+        return ToolResponse::error(format!(
+            "Cannot read non-regular file: {}. Only regular files are supported.",
+            display_path(&routed.canonical)
+        ));
+    }
+    let mut file = match routed.capability.open(&routed.relative) {
+        Ok(file) => file.into_std(),
+        Err(error) => return ToolResponse::error(io_error_message(parsed, &error)),
+    };
+    #[cfg(test)]
+    crate::file_snapshot::tests::notify_original_open(&routed.canonical);
+    let prefix = match read_prefix(&mut file) {
+        Ok(prefix) => prefix,
+        Err(error) => {
+            return ToolResponse::error(io_error_message(parsed, &error));
+        }
+    };
+    if view == ViewMode::Hex {
+        let budget = match tool_token_budget(READ_TOKEN_BUDGET_ENV) {
+            Ok(budget) => budget,
+            Err(message) => return ToolResponse::error(message),
+        };
+        return hex_file::read_hex_handle(
+            file,
+            &routed.canonical,
+            request.offset,
+            request.limit,
+            budget,
+        );
+    }
+    if pdf::is_pdf(&routed.canonical, &prefix) {
+        if request.encoding.is_some() {
+            return ToolResponse::error("The encoding parameter only applies to text files.");
+        }
+        let mode = match pdf::parse_pdf_mode(request.pdf_mode.as_deref()) {
+            Ok(mode) => mode,
+            Err(message) => return ToolResponse::error(message),
+        };
+        let budget = if mode == pdf::PdfMode::Text {
+            match tool_token_budget(READ_TOKEN_BUDGET_ENV) {
+                Ok(budget) => Some(budget),
+                Err(message) => return ToolResponse::error(message),
+            }
+        } else {
+            None
+        };
+        return pdf::read_pdf_handle(
+            file,
+            &routed.canonical,
+            request.pages.as_deref(),
+            mode,
+            budget,
+        );
+    }
+    if request.pages.is_some() {
+        return ToolResponse::error("The pages parameter only applies to PDF files.");
+    }
+    if request.pdf_mode.is_some() {
+        return ToolResponse::error("The pdf_mode parameter only applies to PDF files.");
+    }
+    if image_file::detect_image_mime(&routed.canonical, &prefix).is_some() {
+        if request.encoding.is_some() {
+            return ToolResponse::error("The encoding parameter only applies to text files.");
+        }
+        return image_file::read_image_handle(file, &routed.canonical);
+    }
+    let budget = match tool_token_budget(READ_TOKEN_BUDGET_ENV) {
+        Ok(budget) => budget,
+        Err(message) => return ToolResponse::error(message),
+    };
+    text_file::read_text_handle(
+        &file,
+        &routed.canonical,
+        &routed.display,
+        request.offset,
+        request.limit,
+        request.encoding.as_deref(),
+        detect_binary_type(&prefix),
+        budget,
+    )
+}
+
+pub(super) fn read_prefix(file: &mut fs::File) -> std::io::Result<Vec<u8>> {
+    file.seek(SeekFrom::Start(0))?;
+    let mut prefix = Vec::new();
+    file.take(8 * 1024).read_to_end(&mut prefix)?;
+    file.seek(SeekFrom::Start(0))?;
+    Ok(prefix)
+}
+
 fn parse_view(value: Option<&str>) -> Result<ViewMode, String> {
     match value {
         None | Some("auto") => Ok(ViewMode::Auto),
@@ -244,10 +379,12 @@ fn binary_error_message(path_display: &str, binary_type: Option<&str>) -> String
 
 #[cfg(test)]
 mod tests {
-    use super::{BatchReadEntry, ReadRequest, read_file_with_scope};
+    use super::{BatchReadEntry, ReadRequest, read_file, read_file_with_scope};
     use crate::ToolContent;
     use crate::paths::{ReadScope, display_path};
     use std::fs;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     fn single(path: &std::path::Path) -> ReadRequest {
         ReadRequest {
@@ -267,6 +404,234 @@ mod tests {
             panic!("expected one text response: {response:?}");
         };
         text.clone()
+    }
+
+    #[test]
+    fn restricted_invalid_single_parameters_do_not_open_the_file() {
+        let fixture = tempfile::tempdir().unwrap();
+        let root = fixture.path().join("allowed");
+        fs::create_dir(&root).unwrap();
+        let path = root.join("input.txt");
+        fs::write(&path, b"content").unwrap();
+        let opened = Arc::new(AtomicBool::new(false));
+        let observed = Arc::clone(&opened);
+        let _hook =
+            crate::file_snapshot::tests::OriginalOpenObserverGuard::install(Arc::new(move |_| {
+                observed.store(true, Ordering::Release)
+            }));
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+        let mut request = single(&path);
+        request.view = Some("invalid".to_string());
+        let response = read_file_with_scope(request, &scope);
+        assert!(response.is_error);
+        assert!(!opened.load(Ordering::Acquire));
+
+        let mut request = single(&path);
+        request.view = Some("hex".to_string());
+        request.encoding = Some("utf-8".to_string());
+        let response = read_file_with_scope(request, &scope);
+        assert!(response.is_error);
+        assert!(!opened.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn restricted_small_hex_and_text_pages_do_not_create_sealed_snapshots() {
+        let fixture = tempfile::tempdir().unwrap();
+        let root = fixture.path().join("allowed");
+        fs::create_dir(&root).unwrap();
+        let hex_path = root.join("large.bin");
+        let text_path = root.join("large.txt");
+        fs::write(&hex_path, vec![b'x'; 9 * 1024 * 1024]).unwrap();
+        fs::write(&text_path, b"line\n".repeat(9 * 1024 * 1024 / 5)).unwrap();
+        let snapshots = Arc::new(AtomicUsize::new(0));
+        let observed = Arc::clone(&snapshots);
+        let _observer =
+            crate::file_snapshot::tests::TempCreateObserverGuard::install(Arc::new(move |_| {
+                observed.fetch_add(1, Ordering::AcqRel);
+            }));
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+
+        let mut hex = single(&hex_path);
+        hex.view = Some("hex".to_string());
+        hex.limit = Some(1);
+        let hex_response = read_file_with_scope(hex, &scope);
+        assert!(!hex_response.is_error, "{hex_response:?}");
+
+        let mut text = single(&text_path);
+        text.limit = Some(1);
+        let text_response = read_file_with_scope(text, &scope);
+        assert!(!text_response.is_error, "{text_response:?}");
+        assert!(response_text(text_response).contains("1\tline"));
+        assert_eq!(snapshots.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn restricted_text_matches_unrestricted_full_encoding_contract() {
+        let fixture = tempfile::tempdir().unwrap();
+        let root = fixture.path().join("allowed");
+        fs::create_dir(&root).unwrap();
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+        let mut invalid_tail = b"valid-prefix\n".repeat(800);
+        invalid_tail.push(0xFF);
+        let mut legacy_tail = b"ascii-prefix\n".repeat(800);
+        legacy_tail.extend_from_slice(b"\xC4\xE3\n");
+        let mut iso_2022_tail = b"valid-prefix\n".repeat(800);
+        iso_2022_tail.extend_from_slice(b"\x1B$");
+        let cases = [
+            ("invalid-tail.txt", invalid_tail, None, None),
+            ("legacy-tail.txt", legacy_tail, Some("gbk"), None),
+            ("iso-2022-tail.txt", iso_2022_tail, None, None),
+            ("empty.txt", Vec::new(), None, None),
+            ("unbounded-default.txt", b"\n".repeat(2_099), None, None),
+            (
+                "partial.txt",
+                b"first\nsecond\nthird\n".to_vec(),
+                None,
+                Some(1),
+            ),
+        ];
+        for (name, bytes, encoding, limit) in cases {
+            let path = root.join(name);
+            fs::write(&path, bytes).unwrap();
+            let mut request = single(&path);
+            request.encoding = encoding.map(str::to_string);
+            request.limit = limit;
+            let unrestricted = response_text(read_file(request.clone()));
+            let restricted = response_text(read_file_with_scope(request, &scope));
+            assert_eq!(restricted, unrestricted, "{name}");
+        }
+    }
+
+    #[test]
+    fn restricted_batch_matches_unrestricted_text_contract() {
+        let fixture = tempfile::tempdir().unwrap();
+        let root = fixture.path().join("allowed");
+        fs::create_dir(&root).unwrap();
+        let first = root.join("first.txt");
+        let second = root.join("second.txt");
+        fs::write(&first, b"first\nsecond\n").unwrap();
+        fs::write(&second, b"third\nfourth\n").unwrap();
+        let request = ReadRequest {
+            file_path: None,
+            files: Some(vec![
+                BatchReadEntry {
+                    path: display_path(&first),
+                    offset: Some(2),
+                    limit: Some(1),
+                    encoding: None,
+                },
+                BatchReadEntry {
+                    path: display_path(&second),
+                    offset: None,
+                    limit: None,
+                    encoding: None,
+                },
+            ]),
+            offset: None,
+            limit: None,
+            pages: None,
+            pdf_mode: None,
+            encoding: None,
+            view: None,
+        };
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+        assert_eq!(
+            response_text(read_file_with_scope(request.clone(), &scope)),
+            response_text(read_file(request))
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn restricted_alias_display_matches_unrestricted_single_batch_and_diagnostics() {
+        let fixture = tempfile::tempdir().unwrap();
+        let root = fixture.path().join("allowed");
+        fs::create_dir(&root).unwrap();
+        let target = root.join("target.txt");
+        let alias = root.join("alias.txt");
+        let directory_alias = root.join("directory-alias");
+        fs::write(&target, b"alias content\n").unwrap();
+        std::os::unix::fs::symlink("target.txt", &alias).unwrap();
+        std::os::unix::fs::symlink(".", &directory_alias).unwrap();
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+
+        assert_eq!(
+            response_text(read_file_with_scope(single(&alias), &scope)),
+            response_text(read_file(single(&alias)))
+        );
+        let batch = ReadRequest {
+            file_path: None,
+            files: Some(vec![BatchReadEntry {
+                path: display_path(&alias),
+                offset: None,
+                limit: None,
+                encoding: None,
+            }]),
+            offset: None,
+            limit: None,
+            pages: None,
+            pdf_mode: None,
+            encoding: None,
+            view: None,
+        };
+        assert_eq!(
+            response_text(read_file_with_scope(batch.clone(), &scope)),
+            response_text(read_file(batch))
+        );
+        assert_eq!(
+            response_text(read_file_with_scope(single(&directory_alias), &scope)),
+            response_text(read_file(single(&directory_alias)))
+        );
+    }
+
+    #[test]
+    fn restricted_image_rejects_text_encoding_like_unrestricted_reads() {
+        let fixture = tempfile::tempdir().unwrap();
+        let root = fixture.path().join("allowed");
+        fs::create_dir(&root).unwrap();
+        let path = root.join("image.png");
+        fs::write(&path, b"\x89PNG\r\n\x1a\n").unwrap();
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+        let mut request = single(&path);
+        request.encoding = Some("utf-8".to_string());
+        assert_eq!(
+            response_text(read_file_with_scope(request, &scope)),
+            "The encoding parameter only applies to text files."
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn restricted_image_and_pdf_keep_using_the_open_capability_handle() {
+        let fixture = tempfile::tempdir().unwrap();
+        let root = fixture.path().join("allowed");
+        fs::create_dir(&root).unwrap();
+        let image = root.join("image.png");
+        let pdf = root.join("document.pdf");
+        fs::write(&image, b"\x89PNG\r\n\x1a\n").unwrap();
+        fs::write(&pdf, b"%PDF-original").unwrap();
+        let image_for_hook = image.clone();
+        let pdf_for_hook = pdf.clone();
+        let _hook = crate::file_snapshot::tests::OriginalOpenObserverGuard::install(Arc::new(
+            move |opened| {
+                if opened == image_for_hook {
+                    fs::write(&image_for_hook, b"replacement-image-text").unwrap();
+                } else if opened == pdf_for_hook {
+                    fs::write(&pdf_for_hook, b"replacement-pdf-text").unwrap();
+                }
+            },
+        ));
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+        let image_response = read_file_with_scope(single(&image), &scope);
+        assert!(!image_response.is_error, "{image_response:?}");
+        assert!(matches!(
+            image_response.content[0],
+            ToolContent::Image { .. }
+        ));
+
+        let pdf_response = read_file_with_scope(single(&pdf), &scope);
+        let pdf_text = response_text(pdf_response);
+        assert!(!pdf_text.contains("replacement-pdf-text"), "{pdf_text}");
     }
 
     #[test]
@@ -353,6 +718,137 @@ mod tests {
         assert!(text.contains("allowed-batch-content"), "{text}");
         assert!(text.contains("Permission denied: "), "{text}");
         assert!(!text.contains("denied-batch-content"), "{text}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn restricted_direct_read_pins_open_handle_before_final_component_swap() {
+        let fixture = tempfile::tempdir().unwrap();
+        let root = fixture.path().join("allowed");
+        fs::create_dir(&root).unwrap();
+        let path = root.join("inside.txt");
+        let old_path = root.join("inside.old");
+        fs::write(&path, b"original-inside-bytes").unwrap();
+        let path_for_hook = path.clone();
+        let old_for_hook = old_path.clone();
+        let _hook =
+            crate::file_snapshot::tests::OriginalOpenObserverGuard::install(Arc::new(move |_| {
+                if path_for_hook.exists() {
+                    fs::rename(&path_for_hook, &old_for_hook).unwrap();
+                    fs::write(&path_for_hook, b"replacement-outside-bytes").unwrap();
+                }
+            }));
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+        let response = read_file_with_scope(single(&path), &scope);
+        let text = response_text(response);
+        assert!(text.contains("original-inside-bytes"), "{text}");
+        assert!(!text.contains("replacement-outside-bytes"), "{text}");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn restricted_direct_read_pins_open_handle_before_windows_rename_swap() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let fixture = tempfile::tempdir().unwrap();
+        let root = fixture.path().join("allowed");
+        fs::create_dir(&root).unwrap();
+        let path = root.join("inside.txt");
+        let old_path = root.join("inside.old");
+        fs::write(&path, b"original-windows-bytes").unwrap();
+        let renamed = Arc::new(AtomicBool::new(false));
+        let renamed_for_hook = Arc::clone(&renamed);
+        let path_for_hook = path.clone();
+        let old_for_hook = old_path.clone();
+        let _hook =
+            crate::file_snapshot::tests::OriginalOpenObserverGuard::install(Arc::new(move |_| {
+                if !renamed_for_hook.swap(true, Ordering::AcqRel) {
+                    fs::rename(&path_for_hook, &old_for_hook)
+                        .expect("capability handle must allow a share-delete rename");
+                    fs::write(&path_for_hook, b"replacement-windows-bytes").unwrap();
+                }
+            }));
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+        let text = response_text(read_file_with_scope(single(&path), &scope));
+        assert!(renamed.load(Ordering::Acquire));
+        assert!(text.contains("original-windows-bytes"), "{text}");
+        assert!(!text.contains("replacement-windows-bytes"), "{text}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn restricted_batch_pins_open_handle_for_swapped_entry_and_keeps_neighbor() {
+        let fixture = tempfile::tempdir().unwrap();
+        let root = fixture.path().join("allowed");
+        fs::create_dir(&root).unwrap();
+        let first = root.join("first.txt");
+        let second = root.join("second.txt");
+        let old = root.join("first.old");
+        fs::write(&first, b"original-first").unwrap();
+        fs::write(&second, b"stable-second").unwrap();
+        let first_for_hook = first.clone();
+        let old_for_hook = old.clone();
+        let _hook = crate::file_snapshot::tests::OriginalOpenObserverGuard::install(Arc::new(
+            move |path| {
+                if path == first_for_hook && first_for_hook.exists() {
+                    fs::rename(&first_for_hook, &old_for_hook).unwrap();
+                    fs::write(&first_for_hook, b"replacement-first").unwrap();
+                }
+            },
+        ));
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+        let request = ReadRequest {
+            file_path: None,
+            files: Some(vec![
+                BatchReadEntry {
+                    path: display_path(&first),
+                    offset: None,
+                    limit: None,
+                    encoding: None,
+                },
+                BatchReadEntry {
+                    path: display_path(&second),
+                    offset: None,
+                    limit: None,
+                    encoding: None,
+                },
+            ]),
+            offset: None,
+            limit: None,
+            pages: None,
+            pdf_mode: None,
+            encoding: None,
+            view: None,
+        };
+        let text = response_text(read_file_with_scope(request, &scope));
+        assert!(text.contains("original-first"), "{text}");
+        assert!(text.contains("stable-second"), "{text}");
+        assert!(!text.contains("replacement-first"), "{text}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn restricted_direct_read_pins_open_handle_before_ancestor_swap() {
+        let fixture = tempfile::tempdir().unwrap();
+        let root = fixture.path().join("allowed");
+        let moved = fixture.path().join("allowed.old");
+        fs::create_dir(&root).unwrap();
+        let path = root.join("inside.txt");
+        fs::write(&path, b"original-ancestor-bytes").unwrap();
+        let root_for_hook = root.clone();
+        let moved_for_hook = moved.clone();
+        let _hook =
+            crate::file_snapshot::tests::OriginalOpenObserverGuard::install(Arc::new(move |_| {
+                if root_for_hook.exists() {
+                    fs::rename(&root_for_hook, &moved_for_hook).unwrap();
+                    fs::create_dir(&root_for_hook).unwrap();
+                    fs::write(root_for_hook.join("inside.txt"), b"replacement-ancestor").unwrap();
+                }
+            }));
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+        let text = response_text(read_file_with_scope(single(&path), &scope));
+        assert!(text.contains("original-ancestor-bytes"), "{text}");
+        assert!(!text.contains("replacement-ancestor"), "{text}");
     }
 
     #[test]

--- a/src/read_tool/mod.rs
+++ b/src/read_tool/mod.rs
@@ -16,7 +16,8 @@ use crate::binary::detect_binary_type;
 use crate::budget::{READ_TOKEN_BUDGET_ENV, tool_token_budget};
 use crate::model::ToolResponse;
 use crate::paths::{
-    canonical_existing, display_path, io_error_message, missing_read_file_message, parse_input_path,
+    ReadScope, absolute_path_required_message, canonical_existing, display_path, io_error_message,
+    missing_read_file_message, parse_input_path,
 };
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -100,11 +101,15 @@ pub struct BatchReadEntry {
 
 /// Reads text, images, PDFs, or raw bytes and surfaces every expected failure explicitly.
 pub fn read_file(request: ReadRequest) -> ToolResponse {
+    read_file_with_scope(request, &ReadScope::unrestricted())
+}
+
+pub(crate) fn read_file_with_scope(request: ReadRequest, scope: &ReadScope) -> ToolResponse {
     match (request.file_path.as_deref(), request.files.as_ref()) {
         (Some(_), Some(_)) | (None, None) => {
             return ToolResponse::error("Provide exactly one of file_path or files.");
         }
-        (None, Some(_)) => return batch::read_text_files(request),
+        (None, Some(_)) => return batch::read_text_files(request, scope),
         (Some(_), None) => {}
     }
     let file_path = request
@@ -113,16 +118,23 @@ pub fn read_file(request: ReadRequest) -> ToolResponse {
         .expect("single-file shape was validated");
     let parsed = parse_input_path(file_path);
     if !parsed.is_absolute() {
+        if scope.is_restricted() {
+            return ToolResponse::error(absolute_path_required_message(file_path));
+        }
         return ToolResponse::error(missing_read_file_message(file_path));
     }
-    let metadata = match fs::metadata(&parsed) {
+    let authorized = match scope.authorize(&parsed) {
+        Ok(path) => path,
+        Err(message) => return ToolResponse::error(message),
+    };
+    let metadata = match fs::metadata(&authorized) {
         Ok(metadata) => metadata,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             return ToolResponse::error(missing_read_file_message(file_path));
         }
-        Err(error) => return ToolResponse::error(io_error_message(&parsed, &error)),
+        Err(error) => return ToolResponse::error(io_error_message(&authorized, &error)),
     };
-    let path = canonical_existing(&parsed).unwrap_or(parsed);
+    let path = canonical_existing(&authorized).unwrap_or(authorized);
     let path_display = display_path(&path);
     if metadata.is_dir() {
         return ToolResponse::error(format!(
@@ -228,4 +240,206 @@ fn binary_error_message(path_display: &str, binary_type: Option<&str>) -> String
     format!(
         "Cannot read binary file as text: {path_display}{kind}. Use view=\"hex\" to inspect its raw bytes."
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BatchReadEntry, ReadRequest, read_file_with_scope};
+    use crate::ToolContent;
+    use crate::paths::{ReadScope, display_path};
+    use std::fs;
+
+    fn single(path: &std::path::Path) -> ReadRequest {
+        ReadRequest {
+            file_path: Some(display_path(path)),
+            files: None,
+            offset: None,
+            limit: None,
+            pages: None,
+            pdf_mode: None,
+            encoding: None,
+            view: None,
+        }
+    }
+
+    fn response_text(response: crate::ToolResponse) -> String {
+        let [ToolContent::Text(text)] = response.content.as_slice() else {
+            panic!("expected one text response: {response:?}");
+        };
+        text.clone()
+    }
+
+    #[test]
+    fn scoped_read_allows_direct_files_and_denies_outside_and_lexical_prefixes() {
+        let fixture = tempfile::tempdir().unwrap();
+        let root = fixture.path().join("work");
+        let sibling = fixture.path().join("work-secret");
+        fs::create_dir(&root).unwrap();
+        fs::create_dir(&sibling).unwrap();
+        let inside = root.join("inside.txt");
+        let outside = sibling.join("outside.txt");
+        fs::write(&inside, b"allowed-content").unwrap();
+        fs::write(&outside, b"denied-content").unwrap();
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+
+        let allowed = read_file_with_scope(single(&inside), &scope);
+        assert!(!allowed.is_error, "{allowed:?}");
+        assert!(response_text(allowed).contains("allowed-content"));
+
+        for denied_path in [&outside, &sibling.join("outside.txt")] {
+            let response = read_file_with_scope(single(denied_path), &scope);
+            assert!(response.is_error, "{response:?}");
+            let text = response_text(response);
+            assert!(text.starts_with("Permission denied: "), "{text}");
+            assert!(!text.contains("denied-content"), "{text}");
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn scoped_read_denies_static_file_symlink_without_opening_target() {
+        let fixture = tempfile::tempdir().unwrap();
+        let root = fixture.path().join("allowed");
+        let outside = fixture.path().join("outside.txt");
+        fs::create_dir(&root).unwrap();
+        fs::write(&outside, b"secret-target-content").unwrap();
+        let link = root.join("outside-link.txt");
+        std::os::unix::fs::symlink(&outside, &link).unwrap();
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+
+        let response = read_file_with_scope(single(&link), &scope);
+        assert!(response.is_error, "{response:?}");
+        let text = response_text(response);
+        assert!(text.starts_with("Permission denied: "), "{text}");
+        assert!(!text.contains("secret-target-content"), "{text}");
+    }
+
+    #[test]
+    fn scoped_batch_keeps_allowed_entries_and_reports_denied_entries_inline() {
+        let fixture = tempfile::tempdir().unwrap();
+        let root = fixture.path().join("allowed");
+        let outside = fixture.path().join("outside.txt");
+        fs::create_dir(&root).unwrap();
+        let inside = root.join("inside.txt");
+        fs::write(&inside, b"allowed-batch-content").unwrap();
+        fs::write(&outside, b"denied-batch-content").unwrap();
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+        let request = ReadRequest {
+            file_path: None,
+            files: Some(vec![
+                BatchReadEntry {
+                    path: display_path(&inside),
+                    offset: None,
+                    limit: None,
+                    encoding: None,
+                },
+                BatchReadEntry {
+                    path: display_path(&outside),
+                    offset: None,
+                    limit: None,
+                    encoding: None,
+                },
+            ]),
+            offset: None,
+            limit: None,
+            pages: None,
+            pdf_mode: None,
+            encoding: None,
+            view: None,
+        };
+        let response = read_file_with_scope(request, &scope);
+        assert!(!response.is_error, "{response:?}");
+        let text = response_text(response);
+        assert!(text.contains("allowed-batch-content"), "{text}");
+        assert!(text.contains("Permission denied: "), "{text}");
+        assert!(!text.contains("denied-batch-content"), "{text}");
+    }
+
+    #[test]
+    fn restricted_relative_single_and_batch_requests_use_stable_absolute_errors() {
+        let fixture = tempfile::tempdir().unwrap();
+        let scope = ReadScope::from_allow_roots(&[fixture.path().to_path_buf()]).unwrap();
+        let single_response = read_file_with_scope(
+            ReadRequest {
+                file_path: Some("relative.txt".to_string()),
+                files: None,
+                offset: None,
+                limit: None,
+                pages: None,
+                pdf_mode: None,
+                encoding: None,
+                view: None,
+            },
+            &scope,
+        );
+        assert_eq!(
+            response_text(single_response),
+            "Path must be absolute: relative.txt"
+        );
+
+        let batch_response = read_file_with_scope(
+            ReadRequest {
+                file_path: None,
+                files: Some(vec![BatchReadEntry {
+                    path: "relative.txt".to_string(),
+                    offset: None,
+                    limit: None,
+                    encoding: None,
+                }]),
+                offset: None,
+                limit: None,
+                pages: None,
+                pdf_mode: None,
+                encoding: None,
+                view: None,
+            },
+            &scope,
+        );
+        let text = response_text(batch_response);
+        assert!(
+            text.contains("Path must be absolute: relative.txt"),
+            "{text}"
+        );
+        assert!(!text.contains("session working directory"), "{text}");
+    }
+
+    #[test]
+    fn restricted_batch_denied_aliases_remain_inline_instead_of_duplicate_errors() {
+        let fixture = tempfile::tempdir().unwrap();
+        let root = fixture.path().join("allowed");
+        let outside = fixture.path().join("outside.txt");
+        fs::create_dir(&root).unwrap();
+        fs::write(&outside, b"must-not-leak").unwrap();
+        let alias = root.join("..").join("outside.txt");
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+        let request = ReadRequest {
+            file_path: None,
+            files: Some(vec![
+                BatchReadEntry {
+                    path: display_path(&outside),
+                    offset: None,
+                    limit: None,
+                    encoding: None,
+                },
+                BatchReadEntry {
+                    path: display_path(&alias),
+                    offset: None,
+                    limit: None,
+                    encoding: None,
+                },
+            ]),
+            offset: None,
+            limit: None,
+            pages: None,
+            pdf_mode: None,
+            encoding: None,
+            view: None,
+        };
+        let response = read_file_with_scope(request, &scope);
+        assert!(!response.is_error, "{response:?}");
+        let text = response_text(response);
+        assert_eq!(text.matches("Permission denied: ").count(), 2, "{text}");
+        assert!(!text.contains("must-not-leak"), "{text}");
+        assert!(!text.contains("Duplicate path"), "{text}");
+    }
 }

--- a/src/read_tool/pdf.rs
+++ b/src/read_tool/pdf.rs
@@ -63,26 +63,6 @@ pub(super) fn parse_pdf_mode(value: Option<&str>) -> Result<PdfMode, String> {
     }
 }
 
-pub(super) fn read_pdf(
-    path: &Path,
-    pages_value: Option<&str>,
-    mode: PdfMode,
-    text_budget: Option<TokenBudget>,
-) -> ToolResponse {
-    let path = path.to_path_buf();
-    let path_display = crate::paths::display_path(&path);
-    let pages_value = pages_value.map(str::to_string);
-    match run_pdf_operation(move || {
-        read_pdf_inner(&path, pages_value.as_deref(), mode, text_budget)
-    }) {
-        Ok(response) => response,
-        Err(PdfOperationError::TimedOut) => ToolResponse::error(format!(
-            "PDF operation on {path_display} timed out and was aborted. The file may be malformed; other file types are unaffected."
-        )),
-        Err(PdfOperationError::Unavailable(reason)) => pdf_engine_error(&reason),
-    }
-}
-
 pub(super) fn read_pdf_handle(
     file: File,
     path: &Path,
@@ -101,23 +81,6 @@ pub(super) fn read_pdf_handle(
         )),
         Err(PdfOperationError::Unavailable(reason)) => pdf_engine_error(&reason),
     }
-}
-
-fn read_pdf_inner(
-    path: &Path,
-    pages_value: Option<&str>,
-    mode: PdfMode,
-    text_budget: Option<TokenBudget>,
-) -> ToolResponse {
-    let (_operation, pdfium) = match pdfium_session() {
-        Ok(session) => session,
-        Err(reason) => return pdf_engine_error(&reason),
-    };
-    let document = match pdfium.load_pdf_from_file(path, None) {
-        Ok(document) => document,
-        Err(error) => return pdf_load_error(error),
-    };
-    read_pdf_document(&document, pages_value, mode, text_budget)
 }
 
 fn read_pdf_reader_inner(

--- a/src/read_tool/pdf.rs
+++ b/src/read_tool/pdf.rs
@@ -8,6 +8,7 @@ use image::ImageFormat;
 use pdfium_render::prelude::{PdfDocument, PdfRenderConfig, PdfiumError, PdfiumInternalError};
 use schemars::JsonSchema;
 use serde::Deserialize;
+use std::fs::File;
 use std::io::Cursor;
 use std::path::Path;
 
@@ -82,6 +83,26 @@ pub(super) fn read_pdf(
     }
 }
 
+pub(super) fn read_pdf_handle(
+    file: File,
+    path: &Path,
+    pages_value: Option<&str>,
+    mode: PdfMode,
+    text_budget: Option<TokenBudget>,
+) -> ToolResponse {
+    let path_display = crate::paths::display_path(path);
+    let pages_value = pages_value.map(str::to_string);
+    match run_pdf_operation(move || {
+        read_pdf_reader_inner(file, pages_value.as_deref(), mode, text_budget)
+    }) {
+        Ok(response) => response,
+        Err(PdfOperationError::TimedOut) => ToolResponse::error(format!(
+            "PDF operation on {path_display} timed out and was aborted. The file may be malformed; other file types are unaffected."
+        )),
+        Err(PdfOperationError::Unavailable(reason)) => pdf_engine_error(&reason),
+    }
+}
+
 fn read_pdf_inner(
     path: &Path,
     pages_value: Option<&str>,
@@ -105,6 +126,39 @@ fn read_pdf_inner(
         Err(message) => return ToolResponse::error(message),
     };
 
+    match mode {
+        PdfMode::Text => read_pdf_text(
+            &document,
+            &selected,
+            total_pages,
+            text_budget.expect("text mode always receives a token budget"),
+        ),
+        PdfMode::Image => read_pdf_images(&document, &selected, total_pages),
+    }
+}
+
+fn read_pdf_reader_inner(
+    file: File,
+    pages_value: Option<&str>,
+    mode: PdfMode,
+    text_budget: Option<TokenBudget>,
+) -> ToolResponse {
+    let (_operation, pdfium) = match pdfium_session() {
+        Ok(session) => session,
+        Err(reason) => return pdf_engine_error(&reason),
+    };
+    let document = match pdfium.load_pdf_from_reader(file, None) {
+        Ok(document) => document,
+        Err(error) => return pdf_load_error(error),
+    };
+    let total_pages = document.pages().len() as usize;
+    if total_pages == 0 {
+        return corrupted_pdf();
+    }
+    let selected = match parse_pages(pages_value, total_pages, mode) {
+        Ok(selected) => selected,
+        Err(message) => return ToolResponse::error(message),
+    };
     match mode {
         PdfMode::Text => read_pdf_text(
             &document,

--- a/src/read_tool/pdf.rs
+++ b/src/read_tool/pdf.rs
@@ -117,24 +117,7 @@ fn read_pdf_inner(
         Ok(document) => document,
         Err(error) => return pdf_load_error(error),
     };
-    let total_pages = document.pages().len() as usize;
-    if total_pages == 0 {
-        return corrupted_pdf();
-    }
-    let selected = match parse_pages(pages_value, total_pages, mode) {
-        Ok(selected) => selected,
-        Err(message) => return ToolResponse::error(message),
-    };
-
-    match mode {
-        PdfMode::Text => read_pdf_text(
-            &document,
-            &selected,
-            total_pages,
-            text_budget.expect("text mode always receives a token budget"),
-        ),
-        PdfMode::Image => read_pdf_images(&document, &selected, total_pages),
-    }
+    read_pdf_document(&document, pages_value, mode, text_budget)
 }
 
 fn read_pdf_reader_inner(
@@ -151,6 +134,15 @@ fn read_pdf_reader_inner(
         Ok(document) => document,
         Err(error) => return pdf_load_error(error),
     };
+    read_pdf_document(&document, pages_value, mode, text_budget)
+}
+
+fn read_pdf_document(
+    document: &PdfDocument<'_>,
+    pages_value: Option<&str>,
+    mode: PdfMode,
+    text_budget: Option<TokenBudget>,
+) -> ToolResponse {
     let total_pages = document.pages().len() as usize;
     if total_pages == 0 {
         return corrupted_pdf();
@@ -161,12 +153,12 @@ fn read_pdf_reader_inner(
     };
     match mode {
         PdfMode::Text => read_pdf_text(
-            &document,
+            document,
             &selected,
             total_pages,
             text_budget.expect("text mode always receives a token budget"),
         ),
-        PdfMode::Image => read_pdf_images(&document, &selected, total_pages),
+        PdfMode::Image => read_pdf_images(document, &selected, total_pages),
     }
 }
 

--- a/src/read_tool/pdf_disabled.rs
+++ b/src/read_tool/pdf_disabled.rs
@@ -35,7 +35,8 @@ pub(super) fn parse_pdf_mode(value: Option<&str>) -> Result<PdfMode, String> {
     }
 }
 
-pub(super) fn read_pdf(
+pub(super) fn read_pdf_handle(
+    _file: std::fs::File,
     _path: &Path,
     _pages_value: Option<&str>,
     _mode: PdfMode,
@@ -44,14 +45,4 @@ pub(super) fn read_pdf(
     ToolResponse::error(
         "PDF support is unavailable: could not load the bundled PDF engine (this binary was built without the pdf feature). Other file types are unaffected.",
     )
-}
-
-pub(super) fn read_pdf_handle(
-    _file: std::fs::File,
-    path: &Path,
-    pages_value: Option<&str>,
-    mode: PdfMode,
-    text_budget: Option<TokenBudget>,
-) -> ToolResponse {
-    read_pdf(path, pages_value, mode, text_budget)
 }

--- a/src/read_tool/pdf_disabled.rs
+++ b/src/read_tool/pdf_disabled.rs
@@ -45,3 +45,13 @@ pub(super) fn read_pdf(
         "PDF support is unavailable: could not load the bundled PDF engine (this binary was built without the pdf feature). Other file types are unaffected.",
     )
 }
+
+pub(super) fn read_pdf_handle(
+    _file: std::fs::File,
+    path: &Path,
+    pages_value: Option<&str>,
+    mode: PdfMode,
+    text_budget: Option<TokenBudget>,
+) -> ToolResponse {
+    read_pdf(path, pages_value, mode, text_budget)
+}

--- a/src/read_tool/text_file.rs
+++ b/src/read_tool/text_file.rs
@@ -5,10 +5,14 @@ use super::{
     binary_error_message,
 };
 use crate::budget::{LineTokenCounter, TokenBudget, assemble_text, estimate_tokens};
-use crate::encoding::{EncodingDecision, StreamDecodeFailure, validate_file_encoding};
+use crate::encoding::{
+    ByteSource, EncodingDecision, StreamDecodeFailure, validate_file_encoding,
+    validate_source_encoding,
+};
 use crate::model::ToolResponse;
 use crate::paths::io_error_message;
 use std::fs;
+use std::fs::File;
 use std::path::Path;
 
 pub(super) fn read_text_file(
@@ -56,6 +60,59 @@ pub(super) fn read_text_file(
             return ToolResponse::error(validated.malformed_rejection().message(path_display));
         }
     };
+    if exhausted {
+        collector.finish_eof();
+    }
+    collector.into_response(transcoding_note, budget)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn read_text_handle(
+    file: &File,
+    path: &Path,
+    path_display: &str,
+    offset: Option<usize>,
+    limit: Option<usize>,
+    explicit_encoding: Option<&str>,
+    binary_type: Option<&str>,
+    budget: TokenBudget,
+) -> ToolResponse {
+    let offset = offset.unwrap_or(1);
+    let limit = limit.unwrap_or(UNBOUNDED_LINE_LIMIT);
+    if offset == 0 {
+        return ToolResponse::error("Invalid offset value: 0. Expected an integer >= 1.");
+    }
+    if limit == 0 {
+        return ToolResponse::error("Invalid limit value: 0. Expected an integer >= 1.");
+    }
+    let file_size = match file.metadata() {
+        Ok(metadata) => metadata.len(),
+        Err(error) => return ToolResponse::error(io_error_message(path, &error)),
+    };
+    let validated = match validate_source_encoding(ByteSource::Handle(file), explicit_encoding) {
+        Ok(EncodingDecision::Text(validated)) => validated,
+        Ok(EncodingDecision::Binary) => return binary_error(path_display, binary_type),
+        Ok(EncodingDecision::Rejected(rejection)) => {
+            return ToolResponse::error(rejection.message(path_display));
+        }
+        Err(error) => return ToolResponse::error(io_error_message(path, &error)),
+    };
+    if validated.total_lines == 0 {
+        return ToolResponse::text("Warning: the file exists but is empty.");
+    }
+    let transcoding_note = validated.transcoding_note();
+    let total_is_known = file_size <= TOTAL_COUNT_SIZE_LIMIT;
+    let mut collector = LineCollector::new(offset, limit, budget.value, total_is_known);
+    let exhausted =
+        match validated.stream_source(ByteSource::Handle(file), |chunk| collector.push(chunk)) {
+            Ok(exhausted) => exhausted,
+            Err(StreamDecodeFailure::Io(error)) => {
+                return ToolResponse::error(io_error_message(path, &error));
+            }
+            Err(StreamDecodeFailure::Malformed) => {
+                return ToolResponse::error(validated.malformed_rejection().message(path_display));
+            }
+        };
     if exhausted {
         collector.finish_eof();
     }
@@ -121,6 +178,67 @@ pub(super) fn read_batch_text_file(
             return Err(validated.malformed_rejection().message(path_display));
         }
     };
+    if exhausted {
+        collector.finish_eof();
+    }
+    Ok(BatchTextContent {
+        first: offset,
+        lines: collector.rendered,
+        total_lines,
+        total_is_known,
+        transcoding_note,
+        slice_complete: !collector.storage_saturated,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn read_batch_text_handle(
+    file: &File,
+    path: &Path,
+    path_display: &str,
+    offset: Option<usize>,
+    limit: Option<usize>,
+    explicit_encoding: Option<&str>,
+    binary_type: Option<&str>,
+    collection_budget: usize,
+) -> Result<BatchTextContent, String> {
+    let offset = offset.unwrap_or(1);
+    let limit = limit.unwrap_or(UNBOUNDED_LINE_LIMIT);
+    let file_size = file
+        .metadata()
+        .map_err(|error| io_error_message(path, &error))?
+        .len();
+    let validated = match validate_source_encoding(ByteSource::Handle(file), explicit_encoding)
+        .map_err(|error| io_error_message(path, &error))?
+    {
+        EncodingDecision::Text(validated) => validated,
+        EncodingDecision::Binary => return Err(binary_error_message(path_display, binary_type)),
+        EncodingDecision::Rejected(rejection) => return Err(rejection.message(path_display)),
+    };
+    if validated.total_lines == 0 {
+        return Err("Warning: the file exists but is empty.".to_string());
+    }
+    if validated.total_lines < offset {
+        let noun = if validated.total_lines == 1 {
+            "line"
+        } else {
+            "lines"
+        };
+        return Err(format!(
+            "Warning: the file has only {} {noun}, but offset={offset} was requested.",
+            validated.total_lines
+        ));
+    }
+    let total_lines = validated.total_lines;
+    let total_is_known = file_size <= TOTAL_COUNT_SIZE_LIMIT;
+    let transcoding_note = validated.transcoding_note();
+    let mut collector = LineCollector::new(offset, limit, collection_budget, total_is_known);
+    let exhausted = validated
+        .stream_source(ByteSource::Handle(file), |chunk| collector.push(chunk))
+        .map_err(|error| match error {
+            StreamDecodeFailure::Io(error) => io_error_message(path, &error),
+            StreamDecodeFailure::Malformed => validated.malformed_rejection().message(path_display),
+        })?;
     if exhausted {
         collector.finish_eof();
     }

--- a/src/read_tool/text_file.rs
+++ b/src/read_tool/text_file.rs
@@ -10,39 +10,8 @@ use crate::encoding::{
 };
 use crate::model::ToolResponse;
 use crate::paths::io_error_message;
-use std::fs;
 use std::fs::File;
 use std::path::Path;
-
-pub(super) fn read_text_file(
-    path: &Path,
-    path_display: &str,
-    offset: Option<usize>,
-    limit: Option<usize>,
-    explicit_encoding: Option<&str>,
-    binary_type: Option<&str>,
-    budget: TokenBudget,
-) -> ToolResponse {
-    let (offset, limit) = match read_window(offset, limit) {
-        Ok(window) => window,
-        Err(message) => return ToolResponse::error(message),
-    };
-    let file_size = match fs::metadata(path) {
-        Ok(metadata) => metadata.len(),
-        Err(error) => return ToolResponse::error(io_error_message(path, &error)),
-    };
-    read_text_source(
-        ByteSource::File(path),
-        file_size,
-        path,
-        path_display,
-        offset,
-        limit,
-        explicit_encoding,
-        binary_type,
-        budget,
-    )
-}
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn read_text_handle(
@@ -139,34 +108,6 @@ pub(super) struct BatchTextContent {
     pub(super) total_is_known: bool,
     pub(super) transcoding_note: Option<String>,
     pub(super) slice_complete: bool,
-}
-
-#[allow(clippy::too_many_arguments)]
-pub(super) fn read_batch_text_file(
-    path: &Path,
-    path_display: &str,
-    offset: Option<usize>,
-    limit: Option<usize>,
-    explicit_encoding: Option<&str>,
-    binary_type: Option<&str>,
-    collection_budget: usize,
-) -> Result<BatchTextContent, String> {
-    let offset = offset.unwrap_or(1);
-    let limit = limit.unwrap_or(UNBOUNDED_LINE_LIMIT);
-    let file_size = fs::metadata(path)
-        .map_err(|error| io_error_message(path, &error))?
-        .len();
-    read_batch_text_source(
-        ByteSource::File(path),
-        file_size,
-        path,
-        path_display,
-        offset,
-        limit,
-        explicit_encoding,
-        binary_type,
-        collection_budget,
-    )
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -473,7 +414,7 @@ fn line_span(first: usize, last: usize) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::read_text_file;
+    use super::read_text_handle;
     use crate::ToolContent;
     use crate::budget::TokenBudget;
     use std::fs;
@@ -487,7 +428,9 @@ mod tests {
             ["界".repeat(20), "文".repeat(20), "字".repeat(20)].join("\n"),
         )
         .unwrap();
-        let response = read_text_file(
+        let file = fs::File::open(&path).unwrap();
+        let response = read_text_handle(
+            &file,
             &path,
             "budget.txt",
             None,
@@ -518,7 +461,9 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("tiny-budget.txt");
         fs::write(&path, "content\nmore").unwrap();
-        let response = read_text_file(
+        let file = fs::File::open(&path).unwrap();
+        let response = read_text_handle(
+            &file,
             &path,
             "tiny-budget.txt",
             None,

--- a/src/read_tool/text_file.rs
+++ b/src/read_tool/text_file.rs
@@ -6,8 +6,7 @@ use super::{
 };
 use crate::budget::{LineTokenCounter, TokenBudget, assemble_text, estimate_tokens};
 use crate::encoding::{
-    ByteSource, EncodingDecision, StreamDecodeFailure, validate_file_encoding,
-    validate_source_encoding,
+    ByteSource, EncodingDecision, StreamDecodeFailure, validate_source_encoding,
 };
 use crate::model::ToolResponse;
 use crate::paths::io_error_message;
@@ -24,46 +23,25 @@ pub(super) fn read_text_file(
     binary_type: Option<&str>,
     budget: TokenBudget,
 ) -> ToolResponse {
-    let offset = offset.unwrap_or(1);
-    let limit = limit.unwrap_or(UNBOUNDED_LINE_LIMIT);
-    if offset == 0 {
-        return ToolResponse::error("Invalid offset value: 0. Expected an integer >= 1.");
-    }
-    if limit == 0 {
-        return ToolResponse::error("Invalid limit value: 0. Expected an integer >= 1.");
-    }
+    let (offset, limit) = match read_window(offset, limit) {
+        Ok(window) => window,
+        Err(message) => return ToolResponse::error(message),
+    };
     let file_size = match fs::metadata(path) {
         Ok(metadata) => metadata.len(),
         Err(error) => return ToolResponse::error(io_error_message(path, &error)),
     };
-    let validated = match validate_file_encoding(path, explicit_encoding) {
-        Ok(EncodingDecision::Text(validated)) => validated,
-        Ok(EncodingDecision::Binary) => return binary_error(path_display, binary_type),
-        Ok(EncodingDecision::Rejected(rejection)) => {
-            return ToolResponse::error(rejection.message(path_display));
-        }
-        Err(error) => return ToolResponse::error(io_error_message(path, &error)),
-    };
-    if validated.total_lines == 0 {
-        return ToolResponse::text("Warning: the file exists but is empty.");
-    }
-    let transcoding_note = validated.transcoding_note();
-
-    let total_is_known = file_size <= TOTAL_COUNT_SIZE_LIMIT;
-    let mut collector = LineCollector::new(offset, limit, budget.value, total_is_known);
-    let exhausted = match validated.stream_text(path, |chunk| collector.push(chunk)) {
-        Ok(exhausted) => exhausted,
-        Err(StreamDecodeFailure::Io(error)) => {
-            return ToolResponse::error(io_error_message(path, &error));
-        }
-        Err(StreamDecodeFailure::Malformed) => {
-            return ToolResponse::error(validated.malformed_rejection().message(path_display));
-        }
-    };
-    if exhausted {
-        collector.finish_eof();
-    }
-    collector.into_response(transcoding_note, budget)
+    read_text_source(
+        ByteSource::File(path),
+        file_size,
+        path,
+        path_display,
+        offset,
+        limit,
+        explicit_encoding,
+        binary_type,
+        budget,
+    )
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -77,19 +55,55 @@ pub(super) fn read_text_handle(
     binary_type: Option<&str>,
     budget: TokenBudget,
 ) -> ToolResponse {
-    let offset = offset.unwrap_or(1);
-    let limit = limit.unwrap_or(UNBOUNDED_LINE_LIMIT);
-    if offset == 0 {
-        return ToolResponse::error("Invalid offset value: 0. Expected an integer >= 1.");
-    }
-    if limit == 0 {
-        return ToolResponse::error("Invalid limit value: 0. Expected an integer >= 1.");
-    }
+    let (offset, limit) = match read_window(offset, limit) {
+        Ok(window) => window,
+        Err(message) => return ToolResponse::error(message),
+    };
     let file_size = match file.metadata() {
         Ok(metadata) => metadata.len(),
         Err(error) => return ToolResponse::error(io_error_message(path, &error)),
     };
-    let validated = match validate_source_encoding(ByteSource::Handle(file), explicit_encoding) {
+    read_text_source(
+        ByteSource::Handle(file),
+        file_size,
+        path,
+        path_display,
+        offset,
+        limit,
+        explicit_encoding,
+        binary_type,
+        budget,
+    )
+}
+
+fn read_window(
+    offset: Option<usize>,
+    limit: Option<usize>,
+) -> Result<(usize, usize), &'static str> {
+    let offset = offset.unwrap_or(1);
+    let limit = limit.unwrap_or(UNBOUNDED_LINE_LIMIT);
+    if offset == 0 {
+        return Err("Invalid offset value: 0. Expected an integer >= 1.");
+    }
+    if limit == 0 {
+        return Err("Invalid limit value: 0. Expected an integer >= 1.");
+    }
+    Ok((offset, limit))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn read_text_source(
+    source: ByteSource<'_>,
+    file_size: u64,
+    path: &Path,
+    path_display: &str,
+    offset: usize,
+    limit: usize,
+    explicit_encoding: Option<&str>,
+    binary_type: Option<&str>,
+    budget: TokenBudget,
+) -> ToolResponse {
+    let validated = match validate_source_encoding(source, explicit_encoding) {
         Ok(EncodingDecision::Text(validated)) => validated,
         Ok(EncodingDecision::Binary) => return binary_error(path_display, binary_type),
         Ok(EncodingDecision::Rejected(rejection)) => {
@@ -103,16 +117,15 @@ pub(super) fn read_text_handle(
     let transcoding_note = validated.transcoding_note();
     let total_is_known = file_size <= TOTAL_COUNT_SIZE_LIMIT;
     let mut collector = LineCollector::new(offset, limit, budget.value, total_is_known);
-    let exhausted =
-        match validated.stream_source(ByteSource::Handle(file), |chunk| collector.push(chunk)) {
-            Ok(exhausted) => exhausted,
-            Err(StreamDecodeFailure::Io(error)) => {
-                return ToolResponse::error(io_error_message(path, &error));
-            }
-            Err(StreamDecodeFailure::Malformed) => {
-                return ToolResponse::error(validated.malformed_rejection().message(path_display));
-            }
-        };
+    let exhausted = match validated.stream_source(source, |chunk| collector.push(chunk)) {
+        Ok(exhausted) => exhausted,
+        Err(StreamDecodeFailure::Io(error)) => {
+            return ToolResponse::error(io_error_message(path, &error));
+        }
+        Err(StreamDecodeFailure::Malformed) => {
+            return ToolResponse::error(validated.malformed_rejection().message(path_display));
+        }
+    };
     if exhausted {
         collector.finish_eof();
     }
@@ -143,52 +156,17 @@ pub(super) fn read_batch_text_file(
     let file_size = fs::metadata(path)
         .map_err(|error| io_error_message(path, &error))?
         .len();
-    let validated = match validate_file_encoding(path, explicit_encoding) {
-        Ok(EncodingDecision::Text(validated)) => validated,
-        Ok(EncodingDecision::Binary) => {
-            return Err(binary_error_message(path_display, binary_type));
-        }
-        Ok(EncodingDecision::Rejected(rejection)) => {
-            return Err(rejection.message(path_display));
-        }
-        Err(error) => return Err(io_error_message(path, &error)),
-    };
-    if validated.total_lines == 0 {
-        return Err("Warning: the file exists but is empty.".to_string());
-    }
-    if validated.total_lines < offset {
-        let noun = if validated.total_lines == 1 {
-            "line"
-        } else {
-            "lines"
-        };
-        return Err(format!(
-            "Warning: the file has only {} {noun}, but offset={offset} was requested.",
-            validated.total_lines
-        ));
-    }
-    let total_lines = validated.total_lines;
-    let total_is_known = file_size <= TOTAL_COUNT_SIZE_LIMIT;
-    let transcoding_note = validated.transcoding_note();
-    let mut collector = LineCollector::new(offset, limit, collection_budget, total_is_known);
-    let exhausted = match validated.stream_text(path, |chunk| collector.push(chunk)) {
-        Ok(exhausted) => exhausted,
-        Err(StreamDecodeFailure::Io(error)) => return Err(io_error_message(path, &error)),
-        Err(StreamDecodeFailure::Malformed) => {
-            return Err(validated.malformed_rejection().message(path_display));
-        }
-    };
-    if exhausted {
-        collector.finish_eof();
-    }
-    Ok(BatchTextContent {
-        first: offset,
-        lines: collector.rendered,
-        total_lines,
-        total_is_known,
-        transcoding_note,
-        slice_complete: !collector.storage_saturated,
-    })
+    read_batch_text_source(
+        ByteSource::File(path),
+        file_size,
+        path,
+        path_display,
+        offset,
+        limit,
+        explicit_encoding,
+        binary_type,
+        collection_budget,
+    )
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -208,7 +186,32 @@ pub(super) fn read_batch_text_handle(
         .metadata()
         .map_err(|error| io_error_message(path, &error))?
         .len();
-    let validated = match validate_source_encoding(ByteSource::Handle(file), explicit_encoding)
+    read_batch_text_source(
+        ByteSource::Handle(file),
+        file_size,
+        path,
+        path_display,
+        offset,
+        limit,
+        explicit_encoding,
+        binary_type,
+        collection_budget,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn read_batch_text_source(
+    source: ByteSource<'_>,
+    file_size: u64,
+    path: &Path,
+    path_display: &str,
+    offset: usize,
+    limit: usize,
+    explicit_encoding: Option<&str>,
+    binary_type: Option<&str>,
+    collection_budget: usize,
+) -> Result<BatchTextContent, String> {
+    let validated = match validate_source_encoding(source, explicit_encoding)
         .map_err(|error| io_error_message(path, &error))?
     {
         EncodingDecision::Text(validated) => validated,
@@ -234,7 +237,7 @@ pub(super) fn read_batch_text_handle(
     let transcoding_note = validated.transcoding_note();
     let mut collector = LineCollector::new(offset, limit, collection_budget, total_is_known);
     let exhausted = validated
-        .stream_source(ByteSource::Handle(file), |chunk| collector.push(chunk))
+        .stream_source(source, |chunk| collector.push(chunk))
         .map_err(|error| match error {
             StreamDecodeFailure::Io(error) => io_error_message(path, &error),
             StreamDecodeFailure::Malformed => validated.malformed_rejection().message(path_display),

--- a/src/server.rs
+++ b/src/server.rs
@@ -62,17 +62,9 @@ impl FastCtxServer {
 
     /// Creates one server whose visible tools are selected by startup flags.
     pub fn with_options(options: ServerOptions) -> Self {
-        Self::with_options_and_executor(options, GrepGlobExecutor::shared())
-    }
-
-    /// Creates a server with the process-startup search executor selected by current-user config.
-    pub(crate) fn with_options_and_executor(
-        options: ServerOptions,
-        grep_glob_executor: Arc<GrepGlobExecutor>,
-    ) -> Self {
         Self::with_options_and_executor_and_scope(
             options,
-            grep_glob_executor,
+            GrepGlobExecutor::shared(),
             ReadScope::unrestricted(),
         )
     }
@@ -299,18 +291,57 @@ fn not_a_resource_server() -> ErrorData {
 mod tests {
     use super::{FastCtxServer, ServerOptions};
     use crate::file_executor::GrepGlobExecutor;
-    use crate::paths::ReadScope;
+    use crate::paths::{ReadScope, display_path};
     use crate::search_parallelism::MAX_SEARCH_PARALLELISM;
+    use rmcp::RoleServer;
+    use rmcp::model::{
+        CallToolRequest, CallToolRequestParams, ClientJsonRpcMessage, ClientRequest,
+        NumberOrString, ServerResult,
+    };
+    use rmcp::service::serve_directly;
+    use rmcp::transport::OneshotTransport;
     use std::sync::Arc;
+
+    async fn call_server_tool(
+        server: FastCtxServer,
+        name: &'static str,
+        arguments: serde_json::Value,
+    ) -> rmcp::model::CallToolResult {
+        let arguments = arguments
+            .as_object()
+            .cloned()
+            .expect("tool arguments must be a JSON object");
+        let request = ClientJsonRpcMessage::request(
+            ClientRequest::CallToolRequest(CallToolRequest::new(
+                CallToolRequestParams::new(name).with_arguments(arguments),
+            )),
+            NumberOrString::Number(1),
+        );
+        let (transport, mut responses) = OneshotTransport::<RoleServer>::new(request);
+        let service = serve_directly(server, transport, None);
+        let response = responses
+            .recv()
+            .await
+            .expect("server must respond to a routed tool call");
+        let _ = service.cancel().await;
+        let (ServerResult::CallToolResult(result), _) = response
+            .into_response()
+            .expect("tool call must produce a JSON-RPC response")
+        else {
+            panic!("expected a tools/call response");
+        };
+        result
+    }
 
     #[test]
     fn configured_executor_is_the_server_search_source_for_serial_mid_and_maximum_p() {
         let middle = (MAX_SEARCH_PARALLELISM / 2).max(1);
         for parallelism in [1, middle, MAX_SEARCH_PARALLELISM] {
             let executor = Arc::new(GrepGlobExecutor::with_test_parallelism(parallelism));
-            let server = FastCtxServer::with_options_and_executor(
+            let server = FastCtxServer::with_options_and_executor_and_scope(
                 ServerOptions::default(),
                 Arc::clone(&executor),
+                ReadScope::unrestricted(),
             );
             assert!(Arc::ptr_eq(&server.grep_glob_executor, &executor));
             assert_eq!(server.grep_glob_executor.parallelism(), parallelism);
@@ -318,26 +349,69 @@ mod tests {
         }
     }
 
-    #[test]
-    fn scoped_constructor_retains_the_immutable_read_policy() {
+    #[tokio::test]
+    async fn scoped_server_enforces_file_tool_boundaries() {
         let fixture = tempfile::tempdir().unwrap();
         let root = fixture.path().join("allowed");
-        let outside = fixture.path().join("outside.txt");
+        let outside_root = fixture.path().join("outside");
+        let outside = outside_root.join("outside.txt");
         std::fs::create_dir(&root).unwrap();
+        std::fs::create_dir(&outside_root).unwrap();
         std::fs::write(root.join("inside.txt"), b"inside").unwrap();
-        std::fs::write(&outside, b"outside").unwrap();
+        std::fs::write(&outside, b"outside-secret").unwrap();
         let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
         let server = FastCtxServer::with_options_and_executor_and_scope(
             ServerOptions::default(),
             Arc::new(GrepGlobExecutor::with_test_parallelism(1)),
             scope,
         );
-        assert!(
-            server
-                .read_scope
-                .authorize(&root.join("inside.txt"))
-                .is_ok()
-        );
-        assert!(server.read_scope.authorize(&outside).is_err());
+        let read = call_server_tool(
+            server.clone(),
+            "read",
+            serde_json::json!({"file_path": display_path(&outside)}),
+        )
+        .await;
+        assert_eq!(read.is_error, Some(true), "{read:?}");
+        let read_debug = format!("{read:?}");
+        assert!(read_debug.contains("Permission denied:"), "{read_debug}");
+        assert!(!read_debug.contains("outside-secret"), "{read_debug}");
+
+        let grep = call_server_tool(
+            server.clone(),
+            "grep",
+            serde_json::json!({
+                "pattern": "outside-secret",
+                "path": display_path(&outside_root),
+            }),
+        )
+        .await;
+        assert_eq!(grep.is_error, Some(true), "{grep:?}");
+        let text = grep
+            .content
+            .first()
+            .and_then(|content| content.as_text())
+            .map(|text| text.text.as_str())
+            .expect("expected text error");
+        assert!(text.starts_with("Permission denied: "), "{text}");
+        assert!(!text.contains("outside-secret"), "{text}");
+
+        let glob = call_server_tool(
+            server,
+            "glob",
+            serde_json::json!({
+                "pattern": "**/*",
+                "path": display_path(&outside_root),
+            }),
+        )
+        .await;
+        assert_eq!(glob.is_error, Some(true), "{glob:?}");
+        let text = glob
+            .content
+            .first()
+            .and_then(|content| content.as_text())
+            .map(|text| text.text.as_str())
+            .expect("expected text error");
+        assert!(text.starts_with("Permission denied: "), "{text}");
+        assert!(!text.contains("outside-secret"), "{text}");
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -5,7 +5,8 @@ use crate::edit::ReplaceService;
 use crate::file_executor::GrepGlobExecutor;
 use crate::glob_tool::{GlobRequest, glob_files_cancellable};
 use crate::grep_tool::{GrepRequest, grep_files_cancellable};
-use crate::read_tool::{ReadRequest, read_file};
+use crate::paths::ReadScope;
+use crate::read_tool::{ReadRequest, read_file_with_scope};
 use crate::server_manifest::{ToolContract, ToolManifest};
 use crate::server_support::{BudgetRetry, run_blocking, run_blocking_cancellable};
 use crate::shell::FastShell;
@@ -48,6 +49,7 @@ pub struct FastCtxServer {
     pub(crate) replace: ReplaceService,
     pub(crate) file_permits: Arc<Semaphore>,
     pub(crate) grep_glob_executor: Arc<GrepGlobExecutor>,
+    pub(crate) read_scope: ReadScope,
     pub(crate) shell_permits: Arc<Semaphore>,
     pub(crate) replace_permits: Arc<Semaphore>,
 }
@@ -68,6 +70,18 @@ impl FastCtxServer {
         options: ServerOptions,
         grep_glob_executor: Arc<GrepGlobExecutor>,
     ) -> Self {
+        Self::with_options_and_executor_and_scope(
+            options,
+            grep_glob_executor,
+            ReadScope::unrestricted(),
+        )
+    }
+
+    pub(crate) fn with_options_and_executor_and_scope(
+        options: ServerOptions,
+        grep_glob_executor: Arc<GrepGlobExecutor>,
+        read_scope: ReadScope,
+    ) -> Self {
         let mut tool_router = Self::file_tool_router();
         tool_router.merge(Self::shell_tool_router());
         tool_router.merge(Self::edit_tool_router());
@@ -86,6 +100,7 @@ impl FastCtxServer {
             replace: ReplaceService::new(),
             file_permits: Arc::new(Semaphore::new(MAX_FILE_OPERATIONS)),
             grep_glob_executor,
+            read_scope,
             shell_permits: Arc::new(Semaphore::new(MAX_SHELL_OPERATIONS)),
             replace_permits: Arc::new(Semaphore::new(MAX_REPLACE_OPERATIONS)),
         }
@@ -141,12 +156,13 @@ with the exact parameters a Partial note provides.",
     )]
     async fn read(&self, Parameters(request): Parameters<ReadRequest>) -> CallToolResult {
         let status_shell = self.shell.clone();
+        let scope = self.read_scope.clone();
         run_blocking(
             Arc::clone(&self.file_permits),
             READ_TOKEN_BUDGET_ENV,
             move || status_shell.background_status(None),
             BudgetRetry::Safe,
-            move || read_file(request.clone()),
+            move || read_file_with_scope(request.clone(), &scope),
         )
         .await
     }
@@ -166,6 +182,7 @@ with the exact parameters a Partial note provides.",
         Parameters(request): Parameters<GrepRequest>,
         context: RequestContext<RoleServer>,
     ) -> CallToolResult {
+        let scope = self.read_scope.clone();
         run_blocking_cancellable(
             context.id,
             context.ct,
@@ -176,7 +193,9 @@ with the exact parameters a Partial note provides.",
                 let shell = self.shell.clone();
                 move || shell.background_status(None)
             },
-            move |operation, executor| grep_files_cancellable(operation, executor, request.clone()),
+            move |operation, executor| {
+                grep_files_cancellable(operation, executor, scope.clone(), request.clone())
+            },
         )
         .await
     }
@@ -196,6 +215,7 @@ with the exact parameters a Partial note provides.",
         Parameters(request): Parameters<GlobRequest>,
         context: RequestContext<RoleServer>,
     ) -> CallToolResult {
+        let scope = self.read_scope.clone();
         run_blocking_cancellable(
             context.id,
             context.ct,
@@ -206,7 +226,9 @@ with the exact parameters a Partial note provides.",
                 let shell = self.shell.clone();
                 move || shell.background_status(None)
             },
-            move |operation, executor| glob_files_cancellable(operation, executor, request.clone()),
+            move |operation, executor| {
+                glob_files_cancellable(operation, executor, scope.clone(), request.clone())
+            },
         )
         .await
     }
@@ -277,6 +299,7 @@ fn not_a_resource_server() -> ErrorData {
 mod tests {
     use super::{FastCtxServer, ServerOptions};
     use crate::file_executor::GrepGlobExecutor;
+    use crate::paths::ReadScope;
     use crate::search_parallelism::MAX_SEARCH_PARALLELISM;
     use std::sync::Arc;
 
@@ -293,5 +316,28 @@ mod tests {
             assert_eq!(server.grep_glob_executor.parallelism(), parallelism);
             assert_eq!(server.grep_glob_executor.extra_capacity(), parallelism - 1);
         }
+    }
+
+    #[test]
+    fn scoped_constructor_retains_the_immutable_read_policy() {
+        let fixture = tempfile::tempdir().unwrap();
+        let root = fixture.path().join("allowed");
+        let outside = fixture.path().join("outside.txt");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::write(root.join("inside.txt"), b"inside").unwrap();
+        std::fs::write(&outside, b"outside").unwrap();
+        let scope = ReadScope::from_allow_roots(std::slice::from_ref(&root)).unwrap();
+        let server = FastCtxServer::with_options_and_executor_and_scope(
+            ServerOptions::default(),
+            Arc::new(GrepGlobExecutor::with_test_parallelism(1)),
+            scope,
+        );
+        assert!(
+            server
+                .read_scope
+                .authorize(&root.join("inside.txt"))
+                .is_ok()
+        );
+        assert!(server.read_scope.authorize(&outside).is_err());
     }
 }

--- a/src/traversal.rs
+++ b/src/traversal.rs
@@ -9,6 +9,7 @@ use crate::path_codec::{
     PathRecord, ResolvedRoot, RootKind, display_path as search_display_path,
     io_error_message as search_io_error_message,
 };
+use crate::paths::ReadScope;
 use globset::GlobSet;
 use ignore::types::TypesBuilder;
 use ignore::{DirEntry, WalkBuilder, WalkState};
@@ -186,7 +187,7 @@ fn collect_directory_candidates(
         if !matches_record(&preliminary, glob, None) {
             return Ok(None);
         }
-        candidate_from_entry(entry, &root.native)
+        candidate_from_entry(entry, &root.native, &root.scope)
     })
 }
 
@@ -530,11 +531,15 @@ fn candidate_from_path(
 fn candidate_from_entry(
     entry: &ignore::DirEntry,
     match_root: &Path,
+    scope: &ReadScope,
 ) -> Result<Option<PathRecord>, TraversalFailure> {
     if entry
         .file_type()
         .is_some_and(|file_type| file_type.is_symlink())
     {
+        if let Err(message) = scope.authorize_with_formatter(entry.path(), search_display_path) {
+            return Err(TraversalFailure::from_other(entry.path(), message));
+        }
         return candidate_from_path(entry.path(), match_root);
     }
     match entry.metadata() {

--- a/src/traversal.rs
+++ b/src/traversal.rs
@@ -11,17 +11,21 @@ use crate::path_codec::{
 };
 use crate::paths::ReadScope;
 use globset::GlobSet;
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use ignore::types::TypesBuilder;
-use ignore::{DirEntry, WalkBuilder, WalkState};
+use ignore::{DirEntry, Match as IgnoreMatch, WalkBuilder, WalkState};
 use parking_lot::Mutex;
 use std::fs;
-use std::io;
+use std::io::{self, Read};
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 pub(crate) const TRAVERSAL_BATCH_ITEMS: usize = 256;
+pub(crate) const MAX_IGNORE_CONFIG_BYTES: usize = 1024 * 1024;
+const MAX_GIT_DIR_CONFIG_BYTES: u64 = 64 * 1024;
+const OVERSIZED_IGNORE_CONFIG_ERROR: &str = "Ignore configuration exceeds maximum size.";
 
 /// Legacy replace candidate retained while search uses `PathRecord` directly.
 #[derive(Debug)]
@@ -106,6 +110,9 @@ pub(crate) fn collect_search_candidates(
         return Err("Request cancelled.".to_string());
     }
     let type_filter = build_type_filter(file_type)?;
+    if root.scope.is_restricted() {
+        return collect_capability_candidates(root, glob, type_filter.as_ref(), operation);
+    }
     let mut candidates = Vec::new();
     if root.kind == RootKind::File {
         let candidate =
@@ -121,6 +128,624 @@ pub(crate) fn collect_search_candidates(
     sort_cancelable(candidates, compare_search_candidates, operation, executor)
         .map(|sorted| sorted.items)
         .map_err(|error| error.to_string())
+}
+
+fn collect_capability_candidates(
+    root: &ResolvedRoot,
+    glob: Option<&GlobSet>,
+    type_filter: Option<&ignore::types::Types>,
+    operation: Option<&OperationCtx>,
+) -> Result<Vec<PathRecord>, String> {
+    collect_capability_candidates_filtered(
+        root,
+        glob,
+        type_filter,
+        operation,
+        CapabilityCandidateOptions {
+            honor_ignore: true,
+            detail: CandidateDetail::Metadata,
+            limit: None,
+            limit_message: "",
+        },
+    )
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub(crate) enum CandidateDetail {
+    Path,
+    Metadata,
+}
+
+pub(crate) struct CapabilityCandidateOptions {
+    pub(crate) honor_ignore: bool,
+    pub(crate) detail: CandidateDetail,
+    pub(crate) limit: Option<usize>,
+    pub(crate) limit_message: &'static str,
+}
+
+pub(crate) fn collect_capability_candidates_filtered(
+    root: &ResolvedRoot,
+    glob: Option<&GlobSet>,
+    type_filter: Option<&ignore::types::Types>,
+    operation: Option<&OperationCtx>,
+    options: CapabilityCandidateOptions,
+) -> Result<Vec<PathRecord>, String> {
+    let routed = root
+        .scope
+        .route_with_formatter(&root.native, search_display_path)?;
+    if root.kind == RootKind::File {
+        let candidate = if options.detail == CandidateDetail::Path {
+            PathRecord::without_metadata(&root.native, root.match_root())
+        } else {
+            PathRecord::from_metadata(&root.native, root.match_root(), &root.metadata, true)
+                .map_err(|error| search_io_error_message(&root.native, &error))?
+        };
+        return Ok(matches_record(&candidate, glob, type_filter)
+            .then_some(candidate)
+            .into_iter()
+            .collect());
+    }
+    let mut candidates = Vec::new();
+    let ignore = if options.honor_ignore {
+        CapabilityIgnoreRules::at_root(&routed.capability, &routed.relative, &routed.canonical)?
+    } else {
+        CapabilityIgnoreRules::default()
+    };
+    let context = CapabilityTraversalContext {
+        capability: &routed.capability,
+        match_root: &root.native,
+        scope: &root.scope,
+        honor_ignore: options.honor_ignore,
+        glob,
+        type_filter,
+        detail: options.detail,
+        operation,
+        limit: options.limit,
+        limit_message: options.limit_message,
+    };
+    context.collect_directory(&routed.relative, &root.native, ignore, &mut candidates)?;
+    sort_cancelable(candidates, compare_search_candidates, operation, None)
+        .map(|sorted| sorted.items)
+        .map_err(|error| error.to_string())
+}
+
+struct CapabilityTraversalContext<'a> {
+    capability: &'a Arc<cap_std::fs::Dir>,
+    match_root: &'a Path,
+    scope: &'a ReadScope,
+    honor_ignore: bool,
+    glob: Option<&'a GlobSet>,
+    type_filter: Option<&'a ignore::types::Types>,
+    detail: CandidateDetail,
+    operation: Option<&'a OperationCtx>,
+    limit: Option<usize>,
+    limit_message: &'static str,
+}
+
+impl CapabilityTraversalContext<'_> {
+    fn collect_directory(
+        &self,
+        relative: &Path,
+        native_dir: &Path,
+        ignore: CapabilityIgnoreRules,
+        candidates: &mut Vec<PathRecord>,
+    ) -> Result<(), String> {
+        // The capability walk is deliberately iterative: deeply nested trees must
+        // not consume the process stack, and every child is discovered through the
+        // startup capability rather than an ambient filesystem walk.
+        let mut pending = vec![(relative.to_path_buf(), native_dir.to_path_buf(), ignore)];
+        while let Some((relative, native_dir, ignore)) = pending.pop() {
+            let entries = self
+                .capability
+                .read_dir(&relative)
+                .map_err(|error| search_io_error_message(&native_dir, &error))?;
+            for entry in entries {
+                stage_traversal_entry(self.operation);
+                if operation_cancelled(self.operation) {
+                    return Err("Request cancelled.".to_string());
+                }
+                let entry = entry.map_err(|error| search_io_error_message(&native_dir, &error))?;
+                let name = entry.file_name();
+                let child_native = native_dir.join(&name);
+                let child_relative = relative.join(&name);
+                let file_type = entry
+                    .file_type()
+                    .map_err(|error| search_io_error_message(&child_native, &error))?;
+                if file_type.is_dir() {
+                    if name == ".git" && self.honor_ignore {
+                        continue;
+                    }
+                    if self.honor_ignore && ignore.ignored(&child_native, true) {
+                        // Match WalkBuilder's pruning behavior. A negation below an
+                        // ignored directory is intentionally unreachable.
+                        continue;
+                    }
+                    let child_ignore = if self.honor_ignore {
+                        ignore.descend(self.capability, &child_relative, &child_native)?
+                    } else {
+                        CapabilityIgnoreRules::default()
+                    };
+                    pending.push((child_relative, child_native, child_ignore));
+                    continue;
+                }
+                if !file_type.is_file() && !file_type.is_symlink() {
+                    continue;
+                }
+                if self.honor_ignore && ignore.ignored(&child_native, false) {
+                    continue;
+                }
+                let preliminary = PathRecord::without_metadata(&child_native, self.match_root);
+                if !matches_record(&preliminary, self.glob, self.type_filter) {
+                    continue;
+                }
+                let target = self
+                    .scope
+                    .route_with_formatter(&child_native, search_display_path)?;
+                #[cfg(test)]
+                if file_type.is_symlink() {
+                    crate::file_snapshot::tests::notify_original_open(&child_native);
+                }
+                let metadata = if file_type.is_symlink() || self.detail == CandidateDetail::Metadata
+                {
+                    match target.capability.metadata(&target.relative) {
+                        Ok(metadata) if metadata.is_file() => Some(metadata),
+                        Ok(_) => continue,
+                        Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+                        Err(error) => return Err(search_io_error_message(&child_native, &error)),
+                    }
+                } else {
+                    None
+                };
+                let confirmed = match self
+                    .scope
+                    .route_with_formatter(&child_native, search_display_path)
+                {
+                    Ok(confirmed) => confirmed,
+                    Err(_) => continue,
+                };
+                if confirmed.canonical != target.canonical {
+                    continue;
+                }
+                let candidate = match metadata {
+                    Some(metadata) if self.detail == CandidateDetail::Metadata => {
+                        PathRecord::from_metadata(&child_native, self.match_root, &metadata, true)
+                            .map_err(|error| search_io_error_message(&child_native, &error))?
+                    }
+                    Some(_) | None => preliminary,
+                };
+                {
+                    if self.limit.is_some_and(|limit| candidates.len() >= limit) {
+                        return Err(self.limit_message.to_string());
+                    }
+                    candidates.push(candidate);
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Default)]
+struct CapabilityIgnoreRules {
+    global: MatcherStack,
+    exclude: MatcherStack,
+    gitignore: MatcherStack,
+    ignore: MatcherStack,
+    repository: Option<CapabilityRepository>,
+}
+
+type MatcherStack = Option<Arc<MatcherNode>>;
+
+struct MatcherNode {
+    matcher: Gitignore,
+    parent: MatcherStack,
+}
+
+#[derive(Clone)]
+struct CapabilityRepository {
+    relative: std::path::PathBuf,
+    native: std::path::PathBuf,
+}
+
+impl CapabilityIgnoreRules {
+    fn at_root(
+        capability: &Arc<cap_std::fs::Dir>,
+        root_relative: &Path,
+        root_native: &Path,
+    ) -> Result<Self, String> {
+        let (global, _) = Gitignore::global();
+        let mut rules = Self::default();
+        if !global.is_empty() {
+            push_matcher(&mut rules.global, global);
+        }
+        // `WalkBuilder` loads parent ignore rules even when the request is
+        // routed through a nested capability root. These configuration reads
+        // are the one approved ambient exception: their matchers can only omit
+        // candidates; traversal and every candidate operation stay capability
+        // based.
+        let mut ambient_ancestors = root_native.ancestors().skip(1).collect::<Vec<_>>();
+        ambient_ancestors.reverse();
+        for ancestor in ambient_ancestors {
+            rules.add_ambient_directory(ancestor)?;
+        }
+        let mut native = root_native.to_path_buf();
+        for component in root_relative.components() {
+            if matches!(component, std::path::Component::Normal(_)) {
+                native.pop();
+            }
+        }
+        let mut ancestors = vec![(Path::new(".").to_path_buf(), native.clone())];
+        let mut relative = Path::new(".").to_path_buf();
+        for component in root_relative.components() {
+            if !matches!(component, std::path::Component::Normal(_)) {
+                continue;
+            }
+            relative.push(component.as_os_str());
+            native.push(component.as_os_str());
+            ancestors.push((relative.clone(), native.clone()));
+        }
+
+        for (relative, native) in &ancestors {
+            if is_capability_repository(capability, relative)? {
+                rules.repository = Some(CapabilityRepository {
+                    relative: relative.clone(),
+                    native: native.clone(),
+                });
+                rules.exclude = None;
+                rules.gitignore = None;
+            }
+            if let Some(matcher) = read_capability_ignore(capability, relative, native, ".ignore")?
+            {
+                push_matcher(&mut rules.ignore, matcher);
+            }
+            if let Some(matcher) =
+                read_capability_ignore(capability, relative, native, ".gitignore")?
+            {
+                push_matcher(&mut rules.gitignore, matcher);
+            }
+        }
+        if let Some(repository) = &rules.repository
+            && let Some(matcher) =
+                read_capability_git_exclude(capability, &repository.relative, &repository.native)?
+        {
+            push_matcher(&mut rules.exclude, matcher);
+        }
+        Ok(rules)
+    }
+
+    fn descend(
+        &self,
+        capability: &Arc<cap_std::fs::Dir>,
+        relative: &Path,
+        native: &Path,
+    ) -> Result<Self, String> {
+        let mut rules = self.clone();
+        if is_capability_repository(capability, relative)? {
+            rules.repository = Some(CapabilityRepository {
+                relative: relative.to_path_buf(),
+                native: native.to_path_buf(),
+            });
+            rules.exclude = None;
+            rules.gitignore = None;
+            if let Some(matcher) = read_capability_git_exclude(capability, relative, native)? {
+                push_matcher(&mut rules.exclude, matcher);
+            }
+        }
+        if let Some(matcher) = read_capability_ignore(capability, relative, native, ".ignore")? {
+            push_matcher(&mut rules.ignore, matcher);
+        }
+        if rules.repository.is_some()
+            && let Some(matcher) =
+                read_capability_ignore(capability, relative, native, ".gitignore")?
+        {
+            push_matcher(&mut rules.gitignore, matcher);
+        }
+        Ok(rules)
+    }
+
+    fn add_ambient_directory(&mut self, directory: &Path) -> Result<(), String> {
+        if is_ambient_repository(directory)? {
+            self.repository = Some(CapabilityRepository {
+                relative: std::path::PathBuf::new(),
+                native: directory.to_path_buf(),
+            });
+            self.exclude = None;
+            self.gitignore = None;
+            if let Some(matcher) = read_ambient_git_exclude(directory)? {
+                push_matcher(&mut self.exclude, matcher);
+            }
+        }
+        if let Some(matcher) = read_ambient_ignore(directory, ".ignore")? {
+            push_matcher(&mut self.ignore, matcher);
+        }
+        // Git-related rules are collected from every ancestor, but only used
+        // once a repository exists. This matches WalkBuilder's require-git
+        // gating while retaining rules above the repository boundary.
+        if let Some(matcher) = read_ambient_ignore(directory, ".gitignore")? {
+            push_matcher(&mut self.gitignore, matcher);
+        }
+        Ok(())
+    }
+
+    fn ignored(&self, path: &Path, is_dir: bool) -> bool {
+        // Ignore has four precedence tiers. Within each tier the deepest
+        // directory wins; the tiers themselves are global < exclude <
+        // .gitignore < .ignore, matching ignore::WalkBuilder project filters.
+        let global = self
+            .repository
+            .as_ref()
+            .and_then(|_| ignored_by_matchers(&self.global, path, is_dir));
+        ignored_by_matchers(&self.ignore, path, is_dir)
+            .or_else(|| ignored_by_matchers(&self.gitignore, path, is_dir))
+            .or_else(|| ignored_by_matchers(&self.exclude, path, is_dir))
+            .or(global)
+            .unwrap_or(false)
+    }
+}
+
+fn is_capability_repository(
+    capability: &Arc<cap_std::fs::Dir>,
+    relative: &Path,
+) -> Result<bool, String> {
+    match capability.metadata(relative.join(".git")) {
+        // A worktree's `.git` is a gitdir file. It is still a repository
+        // boundary even when its external common dir is outside the capability.
+        Ok(metadata) => Ok(metadata.is_dir() || metadata.is_file()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(search_io_error_message(&relative.join(".git"), &error)),
+    }
+}
+
+fn is_ambient_repository(directory: &Path) -> Result<bool, String> {
+    match fs::metadata(directory.join(".git")) {
+        Ok(metadata) => Ok(metadata.is_dir() || metadata.is_file()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(search_io_error_message(&directory.join(".git"), &error)),
+    }
+}
+
+fn read_capability_ignore(
+    capability: &Arc<cap_std::fs::Dir>,
+    relative_dir: &Path,
+    native_dir: &Path,
+    name: &str,
+) -> Result<Option<Gitignore>, String> {
+    read_capability_ignore_path(
+        capability,
+        &relative_dir.join(name),
+        native_dir,
+        &native_dir.join(name),
+    )
+}
+
+fn read_capability_git_exclude(
+    capability: &Arc<cap_std::fs::Dir>,
+    repository_relative: &Path,
+    repository_native: &Path,
+) -> Result<Option<Gitignore>, String> {
+    let dot_git = repository_relative.join(".git");
+    let source = repository_native.join(".git");
+    let metadata = match capability.metadata(&dot_git) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(search_io_error_message(&source, &error)),
+    };
+    if metadata.is_dir() {
+        return read_capability_ignore_path(
+            capability,
+            &dot_git.join("info/exclude"),
+            repository_native,
+            &source.join("info/exclude"),
+        );
+    }
+    if !metadata.is_file() {
+        return Ok(None);
+    }
+    let mut file = capability
+        .open(&dot_git)
+        .map_err(|error| search_io_error_message(&source, &error))?;
+    let gitdir = read_first_line(&mut file, &source)?;
+    let Some(gitdir) = gitdir.strip_prefix("gitdir: ") else {
+        return Ok(None);
+    };
+    let common = resolve_worktree_common_dir(&source, gitdir)?;
+    read_ambient_ignore_path(&common.join("info/exclude"), repository_native)
+}
+
+fn read_ambient_git_exclude(repository: &Path) -> Result<Option<Gitignore>, String> {
+    let dot_git = repository.join(".git");
+    let metadata = match fs::metadata(&dot_git) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(search_io_error_message(&dot_git, &error)),
+    };
+    if metadata.is_dir() {
+        return read_ambient_ignore_path(&dot_git.join("info/exclude"), repository);
+    }
+    if !metadata.is_file() {
+        return Ok(None);
+    }
+    let Some(gitdir) = read_ambient_first_line(&dot_git)? else {
+        return Ok(None);
+    };
+    let Some(gitdir) = gitdir.strip_prefix("gitdir: ") else {
+        return Ok(None);
+    };
+    let common = resolve_worktree_common_dir(&dot_git, gitdir)?;
+    read_ambient_ignore_path(&common.join("info/exclude"), repository)
+}
+
+fn resolve_worktree_common_dir(dot_git: &Path, gitdir: &str) -> Result<std::path::PathBuf, String> {
+    let gitdir = resolve_relative_config_path(dot_git.parent().unwrap_or(dot_git), gitdir);
+    let common = read_ambient_first_line(&gitdir.join("commondir"))?
+        .map(|commondir| resolve_relative_config_path(&gitdir, &commondir))
+        .unwrap_or_else(|| gitdir.clone());
+    Ok(common)
+}
+
+fn resolve_relative_config_path(base: &Path, value: &str) -> std::path::PathBuf {
+    let path = Path::new(value);
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        base.join(path)
+    }
+}
+
+fn read_capability_ignore_path(
+    capability: &Arc<cap_std::fs::Dir>,
+    path: &Path,
+    matcher_root: &Path,
+    source: &Path,
+) -> Result<Option<Gitignore>, String> {
+    let file = match capability.open(path) {
+        Ok(file) => file,
+        Err(error)
+            if matches!(
+                error.kind(),
+                io::ErrorKind::NotFound | io::ErrorKind::NotADirectory
+            ) =>
+        {
+            return Ok(None);
+        }
+        Err(error) => return Err(search_io_error_message(source, &error)),
+    };
+    let mut file = file;
+    let contents = read_bounded_ignore_config(&mut file, source)?;
+    build_ignore(matcher_root, source, &contents)
+}
+
+fn read_ambient_ignore(directory: &Path, name: &str) -> Result<Option<Gitignore>, String> {
+    read_ambient_ignore_path(&directory.join(name), directory)
+}
+
+fn read_ambient_ignore_path(
+    source: &Path,
+    matcher_root: &Path,
+) -> Result<Option<Gitignore>, String> {
+    let mut file = match fs::File::open(source) {
+        Ok(file) => file,
+        Err(error)
+            if matches!(
+                error.kind(),
+                io::ErrorKind::NotFound | io::ErrorKind::NotADirectory
+            ) =>
+        {
+            return Ok(None);
+        }
+        Err(error) => return Err(search_io_error_message(source, &error)),
+    };
+    let contents = read_bounded_ignore_config(&mut file, source)?;
+    build_ambient_ignore(matcher_root, source, &contents)
+}
+
+fn read_first_line(file: &mut impl std::io::Read, source: &Path) -> Result<String, String> {
+    let mut contents = String::new();
+    file.take(MAX_GIT_DIR_CONFIG_BYTES)
+        .read_to_string(&mut contents)
+        .map_err(|error| search_io_error_message(source, &error))?;
+    Ok(contents.lines().next().unwrap_or_default().to_string())
+}
+
+fn read_ambient_first_line(source: &Path) -> Result<Option<String>, String> {
+    let mut file = match fs::File::open(source) {
+        Ok(file) => file,
+        Err(error)
+            if matches!(
+                error.kind(),
+                io::ErrorKind::NotFound | io::ErrorKind::NotADirectory
+            ) =>
+        {
+            return Ok(None);
+        }
+        Err(error) => return Err(search_io_error_message(source, &error)),
+    };
+    read_first_line(&mut file, source).map(Some)
+}
+
+fn read_bounded_ignore_config(
+    file: &mut impl std::io::Read,
+    source: &Path,
+) -> Result<String, String> {
+    let mut bytes = Vec::new();
+    file.take((MAX_IGNORE_CONFIG_BYTES.saturating_add(1)) as u64)
+        .read_to_end(&mut bytes)
+        .map_err(|error| search_io_error_message(source, &error))?;
+    if bytes.len() > MAX_IGNORE_CONFIG_BYTES {
+        return Err(OVERSIZED_IGNORE_CONFIG_ERROR.to_string());
+    }
+    String::from_utf8(bytes).map_err(|error| {
+        search_io_error_message(source, &io::Error::new(io::ErrorKind::InvalidData, error))
+    })
+}
+
+fn build_ignore(
+    matcher_root: &Path,
+    source: &Path,
+    contents: &str,
+) -> Result<Option<Gitignore>, String> {
+    let mut builder = GitignoreBuilder::new(matcher_root);
+    for (index, line) in contents.lines().enumerate() {
+        let line = if index == 0 {
+            line.strip_prefix('\u{feff}').unwrap_or(line)
+        } else {
+            line
+        };
+        builder
+            .add_line(Some(source.to_path_buf()), line)
+            .map_err(|error| {
+                format!(
+                    "Cannot parse ignore file {}: {error}",
+                    search_display_path(source)
+                )
+            })?;
+    }
+    builder.build().map(Some).map_err(|error| {
+        format!(
+            "Cannot parse ignore file {}: {error}",
+            search_display_path(source)
+        )
+    })
+}
+
+fn build_ambient_ignore(
+    matcher_root: &Path,
+    source: &Path,
+    contents: &str,
+) -> Result<Option<Gitignore>, String> {
+    let mut builder = GitignoreBuilder::new(matcher_root);
+    for (index, line) in contents.lines().enumerate() {
+        let line = if index == 0 {
+            line.strip_prefix('\u{feff}').unwrap_or(line)
+        } else {
+            line
+        };
+        // Ambient configuration is allowed only to omit candidates. Ignore
+        // malformed entries so an out-of-root pattern cannot surface in a
+        // diagnostic, while valid rules in the same file still apply.
+        let _ = builder.add_line(Some(source.to_path_buf()), line);
+    }
+    Ok(builder.build().ok())
+}
+
+fn push_matcher(stack: &mut MatcherStack, matcher: Gitignore) {
+    *stack = Some(Arc::new(MatcherNode {
+        matcher,
+        parent: stack.clone(),
+    }));
+}
+
+fn ignored_by_matchers(stack: &MatcherStack, path: &Path, is_dir: bool) -> Option<bool> {
+    let mut stack = stack.as_deref();
+    while let Some(node) = stack {
+        let matched = node.matcher.matched(path, is_dir);
+        match matched {
+            IgnoreMatch::Ignore(_) => return Some(true),
+            IgnoreMatch::Whitelist(_) => return Some(false),
+            IgnoreMatch::None => stack = node.parent.as_deref(),
+        }
+    }
+    None
 }
 
 /// Collects files for replace while preserving its pre-codec display contract.

--- a/src/traversal.rs
+++ b/src/traversal.rs
@@ -812,7 +812,7 @@ fn collect_directory_candidates(
         if !matches_record(&preliminary, glob, None) {
             return Ok(None);
         }
-        candidate_from_entry(entry, &root.native, &root.scope)
+        candidate_from_entry(entry, &root.native)
     })
 }
 
@@ -1156,15 +1156,11 @@ fn candidate_from_path(
 fn candidate_from_entry(
     entry: &ignore::DirEntry,
     match_root: &Path,
-    scope: &ReadScope,
 ) -> Result<Option<PathRecord>, TraversalFailure> {
     if entry
         .file_type()
         .is_some_and(|file_type| file_type.is_symlink())
     {
-        if let Err(message) = scope.authorize_with_formatter(entry.path(), search_display_path) {
-            return Err(TraversalFailure::from_other(entry.path(), message));
-        }
         return candidate_from_path(entry.path(), match_root);
     }
     match entry.metadata() {


### PR DESCRIPTION
## Summary

- open configured `--allow-root` directories once as `cap-std` directory capabilities
- route both unrestricted and restricted file acquisition through capability-relative opens and pinned handles
- retain the existing unrestricted `ignore::WalkBuilder` and restricted capability walker for directory traversal
- prevent path-replacement races from reopening a candidate outside its selected root
- preserve existing ignore behavior, including parent and worktree Git rules, while keeping ambient ignore reads bounded and filtering-only
- consolidate shared scoped-access helpers and remove duplicate sorting, canonicalization, and compatibility wrappers
- document the capability boundary, supported symlink behavior, and trusted startup assumptions

## Access flow

```mermaid
flowchart TD
    request[File-tool request] --> operation{File acquisition or directory traversal?}

    operation -->|File acquisition| scoped{Is --allow-root configured?}
    scoped -->|No| ambient[Open an ambient capability at the nearest existing ancestor]
    scoped -->|Yes| restricted[Select the longest matching startup allow-root capability]
    ambient --> relative[Keep the target as a capability-relative locator]
    restricted --> relative
    relative --> opened[Capability-relative metadata and one open]
    opened --> handle[Pinned file handle]
    handle --> read[read or batch: shared prefix classification and format dispatch]
    handle --> grep[grep: snapshot capture plus strict before/after handle identity check]
    read --> content[Return content from the pinned handle]
    grep --> stable{Identity remained stable?}
    stable -->|Yes| matches[Return matches from the captured snapshot]
    stable -->|No| reject[Fail closed and omit the changed candidate]

    operation -->|Directory traversal| traversal{Is --allow-root configured?}
    traversal -->|No| walk[Existing ignore::WalkBuilder]
    traversal -->|Yes| capwalk[Capability walker and candidate revalidation]
    ignore[Parent, worktree, and global ignore rules] -. filtering only .-> walk
    ignore -. filtering only .-> capwalk
    walk --> candidates[Return filtered candidates]
    capwalk --> candidates
```

Without `--allow-root`, FastCtx retains unrestricted path scope and its existing traversal behavior, but file content is now acquired through an ambient capability and consumed from one pinned handle. With `--allow-root`, canonicalization chooses a configured capability but does not grant authority; subsequent metadata, traversal, and content reads use that capability or a pinned handle. Ignore configuration outside a root can only reject candidates.

## Security model

Canonicalization is used only to route an input to the best matching configured root; it does not grant authority. After routing, candidate traversal, metadata, and content access use the selected directory capability or an already authorized handle.

Parent `.ignore`, `.gitignore`, `.git/info/exclude`, worktree `gitdir`/`commondir`, and global Git rules may be read outside an allowed root only to filter candidates. They cannot authorize traversal, open a candidate, or return candidate content. These auxiliary files are size-bounded and their parser errors do not disclose their contents.

The boundary protects against concurrent pathname replacement by other processes. It does not claim to sandbox malicious code running inside the FastCtx process, and configured root acquisition remains a trusted startup operation.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo clippy --locked --all-targets --no-default-features -- -D warnings`
- `cargo test --locked`
- `cargo test --locked --no-default-features`
- `cargo test --locked --release`
- `cargo publish --locked --dry-run --allow-dirty`
- `python3 tools/verify-v011-assets.py`
- `git diff --check`

The final local library suites passed with 544 active all-feature tests and 523 without default features. The optimized all-feature library suite also passed before the final test-only coverage restorations. Native Windows/macOS execution, Rust 1.88 MSRV, and supply-chain jobs remain covered by upstream CI.
