### PR TITLE
fix(server): handle misrouted local resources/read calls

### DIFF
--- a/src/paths.rs
+++ b/src/paths.rs
@@ -13,6 +13,54 @@ pub fn parse_input_path(input: &str) -> PathBuf {
     }
 }
 
+/// Converts a local absolute `file://` URI into the current platform's filesystem path.
+///
+/// This is a narrow compatibility path for hosts that route local files through MCP resources
+/// despite the server omitting the resources capability. Remote authorities and URI decorations
+/// are rejected so the fallback cannot silently reinterpret a different resource identifier.
+pub(crate) fn local_file_uri_to_path(input: &str) -> Option<PathBuf> {
+    if !input
+        .get(..7)
+        .is_some_and(|scheme| scheme.eq_ignore_ascii_case("file://"))
+    {
+        return None;
+    }
+    let url = url::Url::parse(input).ok()?;
+    if url.scheme() != "file"
+        || url.query().is_some()
+        || url.fragment().is_some()
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.port().is_some()
+        || url
+            .host_str()
+            .is_some_and(|host| !host.eq_ignore_ascii_case("localhost"))
+    {
+        return None;
+    }
+    let path = url.to_file_path().ok()?;
+    path.is_absolute().then_some(path)
+}
+
+/// Converts a local absolute path or `file://` URI into a filesystem path.
+///
+/// Generic MCP resource helpers have emitted both forms for the same local file. Plain paths are
+/// accepted only when they are absolute; URI-shaped inputs continue through the stricter
+/// `file://` parser above.
+pub(crate) fn local_resource_path(input: &str) -> Option<PathBuf> {
+    if input
+        .get(..7)
+        .is_some_and(|scheme| scheme.eq_ignore_ascii_case("file://"))
+    {
+        return local_file_uri_to_path(input);
+    }
+    if input.contains("://") {
+        return None;
+    }
+    let path = parse_input_path(input);
+    path.is_absolute().then_some(path)
+}
+
 /// Returns an absolute display path that never depends on platform backslashes.
 pub fn display_path(path: &Path) -> String {
     let mut value = path.to_string_lossy().replace('\\', "/");
@@ -201,7 +249,44 @@ pub fn missing_search_path_message(input: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{file_url_note, missing_file_message, missing_search_path_message};
+    use super::{
+        file_url_note, local_file_uri_to_path, local_resource_path, missing_file_message,
+        missing_search_path_message,
+    };
+
+    #[test]
+    fn local_file_uri_conversion_accepts_only_plain_local_absolute_uris() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("resource notes.txt");
+        let uri = url::Url::from_file_path(&path).unwrap();
+        assert_eq!(local_file_uri_to_path(uri.as_str()), Some(path.clone()));
+        assert_eq!(
+            local_resource_path(&path.to_string_lossy()),
+            Some(path.clone())
+        );
+
+        let mut localhost = uri.clone();
+        localhost.set_host(Some("localhost")).unwrap();
+        assert_eq!(local_file_uri_to_path(localhost.as_str()), Some(path));
+
+        for input in [
+            "https://example.com/resource.txt",
+            "file:relative.txt",
+            "file://server/share/resource.txt",
+            "file:///tmp/resource.txt?download=1",
+            "file:///tmp/resource.txt#line-1",
+            "file://",
+        ] {
+            assert!(local_file_uri_to_path(input).is_none(), "{input}");
+        }
+        for input in [
+            "relative.txt",
+            "https://example.com/resource.txt",
+            "file://server/share/resource.txt",
+        ] {
+            assert!(local_resource_path(input).is_none(), "{input}");
+        }
+    }
 
     #[test]
     fn file_urls_are_translated_to_the_plain_path() {

--- a/src/server.rs
+++ b/src/server.rs
@@ -5,6 +5,8 @@ use crate::edit::ReplaceService;
 use crate::file_executor::GrepGlobExecutor;
 use crate::glob_tool::{GlobRequest, glob_files_cancellable};
 use crate::grep_tool::{GrepRequest, grep_files_cancellable};
+use crate::model::{ImageDetail, ToolContent, ToolResponse};
+use crate::paths::local_resource_path;
 use crate::read_tool::{ReadRequest, read_file};
 use crate::server_manifest::{ToolContract, ToolManifest};
 use crate::server_support::{BudgetRetry, run_blocking, run_blocking_cancellable};
@@ -13,8 +15,8 @@ use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{
     CallToolResult, ErrorCode, ErrorData, Implementation, ListResourceTemplatesResult,
-    ListResourcesResult, PaginatedRequestParams, ReadResourceRequestParams, ReadResourceResult,
-    ServerCapabilities, ServerInfo,
+    ListResourcesResult, Meta, PaginatedRequestParams, ReadResourceRequestParams,
+    ReadResourceResult, ResourceContents, ServerCapabilities, ServerInfo,
 };
 use rmcp::service::RequestContext;
 use rmcp::{RoleServer, ServerHandler, tool, tool_handler, tool_router};
@@ -249,22 +251,59 @@ impl ServerHandler for FastCtxServer {
 
     async fn read_resource(
         &self,
-        _request: ReadResourceRequestParams,
+        request: ReadResourceRequestParams,
         _context: RequestContext<RoleServer>,
     ) -> Result<ReadResourceResult, ErrorData> {
-        Err(not_a_resource_server())
+        let uri = request.uri;
+        let path = local_resource_path(&uri).ok_or_else(|| {
+            ErrorData::invalid_params(
+                "FastCtx resources/read compatibility accepts only an absolute local path or local file:// URI; remote URIs, queries, and fragments are rejected.",
+                None,
+            )
+        })?;
+        let file_path = path.to_str().map(str::to_owned).ok_or_else(|| {
+            ErrorData::invalid_params(
+                "The local resource path cannot be represented as UTF-8.",
+                None,
+            )
+        })?;
+        let permit = Arc::clone(&self.file_permits)
+            .acquire_owned()
+            .await
+            .map_err(|_| {
+                ErrorData::internal_error(
+                    "The blocking-operation limiter is unavailable for resources/read.",
+                    None,
+                )
+            })?;
+        let response = tokio::task::spawn_blocking(move || {
+            let _permit = permit;
+            read_file(ReadRequest {
+                file_path: Some(file_path),
+                files: None,
+                offset: None,
+                limit: None,
+                pages: None,
+                pdf_mode: None,
+                encoding: None,
+                view: None,
+            })
+        })
+        .await
+        .map_err(|error| {
+            ErrorData::internal_error(format!("Internal resource read failure: {error}"), None)
+        })?;
+        resource_read_result(uri, response)
     }
 }
 
-/// Rejection shared by every `resources/*` method, naming the tool that actually does the job.
+/// Rejection shared by the resource discovery methods, naming the tools that do those jobs.
 ///
 /// 2026-07-24: hosts publish generic resource tools for every configured MCP server without
 /// checking whether the server declared the `resources` capability, so these methods are reachable
-/// even though FastCtx never advertises them. The SDK default would answer the two list methods
-/// with an empty array, which reads as "this server does resources and happens to have none" and
-/// invites a follow-up read of an invented URI; one rejection for all three cuts that off at the
-/// first step. Callers arrive holding a `file://` URL, so the recovery names the parameter shape
-/// as well as the tool.
+/// even though FastCtx never advertises them. The SDK default would answer these methods with an
+/// empty array, which reads as "this server does resources and happens to have none" and invites a
+/// follow-up read of an invented URI.
 fn not_a_resource_server() -> ErrorData {
     ErrorData::new(
         ErrorCode::METHOD_NOT_FOUND,
@@ -273,12 +312,103 @@ fn not_a_resource_server() -> ErrorData {
     )
 }
 
+fn resource_read_result(
+    uri: String,
+    response: ToolResponse,
+) -> Result<ReadResourceResult, ErrorData> {
+    let ToolResponse { content, is_error } = response;
+    if is_error {
+        let message = content
+            .into_iter()
+            .filter_map(|block| match block {
+                ToolContent::Text(text) => Some(text),
+                ToolContent::Image { .. } => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        return Err(ErrorData::invalid_params(
+            if message.is_empty() {
+                "The local resource could not be read.".to_string()
+            } else {
+                message
+            },
+            None,
+        ));
+    }
+    let contents = content
+        .into_iter()
+        .map(|block| match block {
+            ToolContent::Text(text) => ResourceContents::text(text, uri.clone()),
+            ToolContent::Image {
+                data,
+                mime_type,
+                detail,
+            } => {
+                let contents = ResourceContents::blob(data, uri.clone()).with_mime_type(mime_type);
+                if detail == Some(ImageDetail::High) {
+                    let mut meta = Meta::new();
+                    meta.0.insert(
+                        "codex/imageDetail".to_string(),
+                        serde_json::Value::String("high".to_string()),
+                    );
+                    contents.with_meta(meta)
+                } else {
+                    contents
+                }
+            }
+        })
+        .collect();
+    Ok(ReadResourceResult::new(contents))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{FastCtxServer, ServerOptions};
+    use super::{FastCtxServer, ServerOptions, resource_read_result};
+    use crate::ToolResponse;
     use crate::file_executor::GrepGlobExecutor;
+    use crate::model::{ImageDetail, ToolContent};
     use crate::search_parallelism::MAX_SEARCH_PARALLELISM;
+    use rmcp::model::ErrorCode;
     use std::sync::Arc;
+
+    #[test]
+    fn resource_read_result_preserves_text_and_image_content() {
+        let result = resource_read_result(
+            "file:///C:/notes.txt".to_string(),
+            ToolResponse {
+                content: vec![
+                    ToolContent::Text("1\tline".to_string()),
+                    ToolContent::Image {
+                        data: "aW1hZ2U=".to_string(),
+                        mime_type: "image/png".to_string(),
+                        detail: Some(ImageDetail::High),
+                    },
+                ],
+                is_error: false,
+            },
+        )
+        .unwrap();
+        let value = serde_json::to_value(result).unwrap();
+        assert_eq!(value["contents"][0]["uri"], "file:///C:/notes.txt");
+        assert_eq!(value["contents"][0]["mimeType"], "text/plain");
+        assert_eq!(value["contents"][0]["text"], "1\tline");
+        assert_eq!(value["contents"][1]["uri"], "file:///C:/notes.txt");
+        assert_eq!(value["contents"][1]["mimeType"], "image/png");
+        assert_eq!(value["contents"][1]["blob"], "aW1hZ2U=");
+        assert_eq!(value["contents"][1]["_meta"]["codex/imageDetail"], "high");
+    }
+
+    #[test]
+    fn resource_read_result_surfaces_tool_errors_as_protocol_errors() {
+        let error = resource_read_result(
+            "file:///C:/missing.txt".to_string(),
+            ToolResponse::error("File does not exist: C:/missing.txt"),
+        )
+        .unwrap_err();
+        assert_eq!(error.code, ErrorCode::INVALID_PARAMS);
+        assert_eq!(error.message, "File does not exist: C:/missing.txt");
+        assert!(error.data.is_none());
+    }
 
     #[test]
     fn configured_executor_is_the_server_search_source_for_serial_mid_and_maximum_p() {

--- a/tests/server_contract.rs
+++ b/tests/server_contract.rs
@@ -658,7 +658,14 @@ fn stdio_pdf_call_extracts_one_hashed_engine_and_preserves_image_meta() {
 }
 
 #[test]
-fn stdio_mcp_is_tool_only_lists_tools_and_never_returns_structured_content() {
+fn stdio_mcp_stays_tool_only_but_accepts_misrouted_local_file_reads() {
+    let temp = tempfile::tempdir().unwrap();
+    let resource_path = temp.path().join("resource notes.txt");
+    write(&resource_path, "compatibility read\n");
+    let resource_uri = url::Url::from_file_path(&resource_path)
+        .expect("temporary file path should convert to a file URI")
+        .to_string();
+
     let mut child = Command::new(env!("CARGO_BIN_EXE_fastctx"))
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -722,21 +729,59 @@ fn stdio_mcp_is_tool_only_lists_tools_and_never_returns_structured_content() {
     assert!(called["result"].get("structuredContent").is_none());
     assert_eq!(called["result"]["content"][0]["type"], "text");
 
-    // All three resource methods must answer alike. An empty list from the SDK default would
-    // read as "this server does resources and has none", which is the step upstream hosts turn
-    // into a follow-up read of an invented URI (2026-07-24).
-    for (id, method, params) in [
-        (
-            4,
-            "resources/read",
-            serde_json::json!({"uri":"file:///Z:/definitely/missing.txt"}),
-        ),
-        (5, "resources/list", serde_json::json!({})),
-        (6, "resources/templates/list", serde_json::json!({})),
-    ] {
+    // Some hosts still route a local file URI through resources/read even when the server omits
+    // the resources capability. Accept that one defensive compatibility path so the host does
+    // not surface a repeated protocol error.
+    send(
+        &mut stdin,
+        serde_json::json!({
+            "jsonrpc":"2.0",
+            "id":4,
+            "method":"resources/read",
+            "params":{"uri":resource_uri}
+        }),
+    );
+    let resource = read_response(&mut stdout);
+    assert_eq!(resource["id"], 4);
+    assert!(resource.get("error").is_none(), "{resource}");
+    assert_eq!(resource["result"]["contents"][0]["uri"], resource_uri);
+    assert_eq!(resource["result"]["contents"][0]["mimeType"], "text/plain");
+    assert!(
+        resource["result"]["contents"][0]["text"]
+            .as_str()
+            .is_some_and(|text| text.contains("1\tcompatibility read")),
+        "{resource}"
+    );
+
+    // The same host path is also observed as a plain Windows absolute path. Keep the response URI
+    // byte-for-byte identical to the request so generic clients can correlate the result.
+    let plain_path = resource_path.to_string_lossy().into_owned();
+    send(
+        &mut stdin,
+        serde_json::json!({
+            "jsonrpc":"2.0",
+            "id":5,
+            "method":"resources/read",
+            "params":{"uri":plain_path}
+        }),
+    );
+    let plain_resource = read_response(&mut stdout);
+    assert_eq!(plain_resource["id"], 5);
+    assert!(plain_resource.get("error").is_none(), "{plain_resource}");
+    assert_eq!(plain_resource["result"]["contents"][0]["uri"], plain_path);
+    assert!(
+        plain_resource["result"]["contents"][0]["text"]
+            .as_str()
+            .is_some_and(|text| text.contains("1\tcompatibility read")),
+        "{plain_resource}"
+    );
+
+    // Resource discovery remains rejected. Empty SDK-default lists imply a real resource surface
+    // and invite hosts to invent another URI after the compatibility read (2026-07-31).
+    for (id, method) in [(6, "resources/list"), (7, "resources/templates/list")] {
         send(
             &mut stdin,
-            serde_json::json!({"jsonrpc":"2.0","id":id,"method":method,"params":params}),
+            serde_json::json!({"jsonrpc":"2.0","id":id,"method":method,"params":{}}),
         );
         let rejected = read_response(&mut stdout);
         assert_eq!(rejected["id"], id, "{method}");


### PR DESCRIPTION
## Summary

FastCtx is configured as a tool-only MCP server, but some Codex hosts still route local-file reads through `resources/read` (tracked in #18). This patch adds a narrow compatibility handler for that misroute without advertising MCP resources.

## Changes

- Keep `capabilities.resources` absent.
- Accept `resources/read` only for an absolute local filesystem path or a local `file://` URI.
- Reject remote authorities, non-file schemes, queries, fragments, userinfo, and ports.
- Reuse `read_tool::read_file` so encoding detection, token budgets, PDF/image handling, and file validation stay consistent.
- Map text and image tool content to MCP resource contents, including high image-detail metadata.
- Keep `resources/list` and `resources/templates/list` returning `-32601`.

## Validation

- Stdio regression covers percent-encoded local `file://` URIs and plain Windows absolute paths.
- Resource discovery remains rejected and the resources capability remains absent.
- `cargo fmt --check`
- `cargo clippy --locked --no-default-features --all-targets -- -D warnings`
- Focused debug and release stdio contract tests pass on Windows.

Refs #18