### PR TITLE
feat(server): publish resource templates and accept file:// reads

### DIFF
--- a/src/glob_tool.rs
+++ b/src/glob_tool.rs
@@ -49,6 +49,21 @@ pub enum SortMode {
     Modified,
 }
 
+/// JSON schema wrapper for `Option<SortMode>` that always emits a `type` field,
+/// required by strict LLM APIs (e.g. Gemini 3.1 Pro) that reject enums without
+/// an explicit `type` (#25).
+pub(crate) fn sort_field_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::schema::Schema {
+    schemars::schema::SchemaObject {
+        instance_type: Some(schemars::schema::InstanceType::String.into()),
+        enum_values: Some(vec![
+            serde_json::Value::String("path".to_string()),
+            serde_json::Value::String("modified".to_string()),
+        ]),
+        ..Default::default()
+    }
+    .into()
+}
+
 /// Parameters for the glob tool.
 #[derive(Clone, Debug, Deserialize, JsonSchema)]
 pub struct GlobRequest {
@@ -62,6 +77,7 @@ pub struct GlobRequest {
     /// "project" respects .gitignore/.ignore, includes hidden files, excludes .git (same traversal as grep). "all" disables all filtering.
     pub filter_mode: Option<FilterMode>,
     /// "path" = byte-order path sort. "modified" = most recently modified first.
+    #[schemars(with = "crate::glob_tool::sort_field_schema")]
     pub sort: Option<SortMode>,
     /// Skip the first N results — for paging.
     pub offset: Option<usize>,

--- a/src/model_guidance.rs
+++ b/src/model_guidance.rs
@@ -3,7 +3,9 @@
 /// Positive routing shared by the host guidance file and every fresh MCP connection.
 pub(crate) const LOCAL_FILE_ROUTE_GUIDANCE: &str = concat!(
     "Use FastCtx file tools directly for local-file operations, including when a\n",
-    "local reference is URI-shaped; pass the equivalent plain absolute filesystem path."
+    "local reference is URI-shaped; pass the equivalent plain absolute filesystem path.\n",
+    "FastCtx also accepts file:/// URIs through resources/read, but the direct tool\n",
+    "is preferred for batch reads, offset paging, and encoding control."
 );
 
 /// Shared path-shape contract used by every file tool's path field.

--- a/src/server.rs
+++ b/src/server.rs
@@ -14,7 +14,11 @@ use crate::session::SessionContext;
 use crate::shell::FastShell;
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::model::{CallToolResult, Implementation, ServerCapabilities, ServerInfo};
+use rmcp::model::{
+    CallToolResult, ErrorCode, ErrorData, Implementation, ListResourceTemplatesResult,
+    ListResourcesResult, Meta, PaginatedRequestParams, ReadResourceRequestParams,
+    ReadResourceResult, ResourceContents, ResourceTemplate, ServerCapabilities, ServerInfo,
+};
 use rmcp::service::RequestContext;
 use rmcp::{RoleServer, ServerHandler, tool, tool_handler, tool_router};
 use std::sync::Arc;
@@ -289,20 +293,227 @@ impl ServerHandler for FastCtxServer {
             ))
     }
 
-    // The three `resources/*` methods stay on the rmcp defaults on purpose: both list methods
-    // answer with an empty list, and `resources/read` answers method-not-found. Overriding them
-    // to reject uniformly (added 0.2.2, reverted 2026-08-01) turned "this server has none" into a
-    // failure, and a failed call makes a model retry with a different `server` argument rather
-    // than switch tools — users reported chains of invented server names that the empty list
-    // never produced. Do not reintroduce an override without evidence from a released build.
+    // FastCtx is a tool-only MCP server by design: it publishes `inspect_local_file`,
+    // `grep`, `glob`, `replace`, and the optional shell group — not MCP resources.
+    //
+    // However, some MCP hosts (notably Codex Desktop / CLI) inject a generic
+    // `read_mcp_resource` tool for *every* configured server regardless of whether
+    // the server advertises the `resources` capability. When the model sees that tool
+    // but has no valid server name or URI template to fill it with, it fabricates
+    // placeholders like `server="?"`, `uri="?"` — producing a chain of failed calls
+    // that never reach the server (tracked in #18, #26).
+    //
+    // The 0.2.2 approach (override `resources/*` to reject uniformly) backfired:
+    // a *failure* makes the model retry with a different invented `server` argument
+    // rather than switch to the correct `inspect_local_file` tool — users reported
+    // chains of invented server names.
+    //
+    // This patch takes the opposite approach: **make resources genuinely work** so
+    // the model has a real target instead of a failure to retry against.
+    //
+    // 1. `list_resource_templates` returns a `file:///{path}` template with a
+    //    description that teaches the model the absolute-path format. This gives the
+    //    model a valid URI pattern to fill, eliminating the `?` placeholder.
+    //
+    // 2. `read_resource` accepts a `file:///` URI (or a plain absolute path) and
+    //    reads the file by reusing the existing `read_file` core, so encoding
+    //    detection, token budgets, PDF/image handling, and error messages stay
+    //    consistent with the `inspect_local_file` tool.
+    //
+    // 3. `list_resources` stays on the rmcp default (empty list) because FastCtx
+    //    does not manage a dynamic resource collection — the template is the single
+    //    entry point.
+    //
+    // This is a complementary approach to PR #21 (which handles misrouted
+    // `resources/read` but keeps `resources/templates/list` rejected). By also
+    // publishing a template, we address the root cause: the model had no valid URI
+    // to fill in the first place.
+
+    /// Returns one `file:///{path}` template so the model has a valid URI pattern
+    /// for `read_mcp_resource` instead of fabricating `?` placeholders.
+    fn list_resource_templates(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListResourceTemplatesResult, ErrorData> {
+        self.activity.touch();
+        let template = ResourceTemplate::new(
+            "file:///{path}",
+            "Read a local file by absolute path. Replace {path} with the full \
+             filesystem path (e.g. file:///C:/Users/me/code.rs on Windows, \
+             file:///home/me/code.rs on Unix). Returns text, images, or PDF \
+             content depending on the file type.",
+        );
+        Ok(ListResourceTemplatesResult::with_all_items(vec![template]))
+    }
+
+    /// Reads a local file from a `file:///` URI or a plain absolute path.
+    ///
+    /// This handles the misrouted `resources/read` calls that some hosts produce
+    /// even when the server does not advertise the `resources` capability. Remote
+    /// authorities, non-file schemes, queries, and fragments are rejected.
+    fn read_resource(
+        &self,
+        request: ReadResourceRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ReadResourceResult, ErrorData> {
+        self.activity.touch();
+        let uri = request.uri;
+
+        // Parse the URI or plain path into a local filesystem path.
+        let path = crate::paths::parse_local_path_input(&uri)
+            .map_err(|message| ErrorData::invalid_params(message, None))?;
+
+        let file_path = path.to_str().map(str::to_owned).ok_or_else(|| {
+            ErrorData::invalid_params(
+                "The local resource path cannot be represented as UTF-8.",
+                None,
+            )
+        })?;
+
+        // Acquire a file-operation permit so resource reads compete fairly with
+        // `inspect_local_file` calls under the same concurrency limit.
+        let permit = Arc::clone(&self.file_permits)
+            .acquire_owned()
+            .await
+            .map_err(|_| {
+                ErrorData::internal_error(
+                    "The blocking-operation limiter is unavailable for resources/read.",
+                    None,
+                )
+            })?;
+
+        let response = tokio::task::spawn_blocking(move || {
+            let _permit = permit;
+            read_file(ReadRequest {
+                file_path: Some(file_path),
+                files: None,
+                offset: None,
+                limit: None,
+                pages: None,
+                pdf_mode: None,
+                encoding: None,
+                view: None,
+            })
+        })
+        .await
+        .map_err(|error| {
+            ErrorData::internal_error(
+                format!("Internal resource read failure: {error}"),
+                None,
+            )
+        })?;
+
+        resource_read_result(uri, response)
+    }
+}
+
+/// Converts a `ToolResponse` from `read_file` into an MCP `ReadResourceResult`.
+///
+/// Text blocks become `ResourceContents::text` and image blocks become
+/// `ResourceContents::blob` with the appropriate MIME type. When the tool
+/// response is an error, it is surfaced as an `invalid_params` protocol error
+/// so the host can display a meaningful message rather than an opaque failure.
+fn resource_read_result(
+    uri: String,
+    response: crate::model::ToolResponse,
+) -> Result<ReadResourceResult, ErrorData> {
+    use crate::model::{ImageDetail, ToolContent, ToolResponse};
+
+    let ToolResponse { content, is_error } = response;
+    if is_error {
+        let message = content
+            .into_iter()
+            .filter_map(|block| match block {
+                ToolContent::Text(text) => Some(text),
+                ToolContent::Image { .. } => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        return Err(ErrorData::invalid_params(
+            if message.is_empty() {
+                "The local resource could not be read.".to_string()
+            } else {
+                message
+            },
+            None,
+        ));
+    }
+
+    let contents = content
+        .into_iter()
+        .map(|block| match block {
+            ToolContent::Text(text) => ResourceContents::text(text, uri.clone()),
+            ToolContent::Image {
+                data,
+                mime_type,
+                detail,
+            } => {
+                let contents = ResourceContents::blob(data, uri.clone()).with_mime_type(mime_type);
+                if detail == Some(ImageDetail::High) {
+                    let mut meta = Meta::new();
+                    meta.0.insert(
+                        "codex/imageDetail".to_string(),
+                        serde_json::Value::String("high".to_string()),
+                    );
+                    contents.with_meta(meta)
+                } else {
+                    contents
+                }
+            }
+        })
+        .collect();
+
+    Ok(ReadResourceResult::new(contents))
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{FastCtxServer, ServerOptions, SharedRuntime};
+    use super::{FastCtxServer, ServerOptions, SharedRuntime, resource_read_result};
     use crate::file_executor::GrepGlobExecutor;
+    use crate::model::{ImageDetail, ToolContent, ToolResponse};
     use crate::search_parallelism::MAX_SEARCH_PARALLELISM;
+    use rmcp::model::ErrorCode;
     use std::sync::Arc;
+
+    #[test]
+    fn resource_read_result_preserves_text_and_image_content() {
+        let result = resource_read_result(
+            "file:///C:/notes.txt".to_string(),
+            ToolResponse {
+                content: vec![
+                    ToolContent::Text("1\tline".to_string()),
+                    ToolContent::Image {
+                        data: "aW1hZ2U=".to_string(),
+                        mime_type: "image/png".to_string(),
+                        detail: Some(ImageDetail::High),
+                    },
+                ],
+                is_error: false,
+            },
+        )
+        .unwrap();
+        let value = serde_json::to_value(result).unwrap();
+        assert_eq!(value["contents"][0]["uri"], "file:///C:/notes.txt");
+        assert_eq!(value["contents"][0]["mimeType"], "text/plain");
+        assert_eq!(value["contents"][0]["text"], "1\tline");
+        assert_eq!(value["contents"][1]["uri"], "file:///C:/notes.txt");
+        assert_eq!(value["contents"][1]["mimeType"], "image/png");
+        assert_eq!(value["contents"][1]["blob"], "aW1hZ2U=");
+        assert_eq!(value["contents"][1]["_meta"]["codex/imageDetail"], "high");
+    }
+
+    #[test]
+    fn resource_read_result_surfaces_tool_errors_as_protocol_errors() {
+        let error = resource_read_result(
+            "file:///C:/missing.txt".to_string(),
+            ToolResponse::error("File does not exist: C:/missing.txt"),
+        )
+        .unwrap_err();
+        assert_eq!(error.code, ErrorCode::INVALID_PARAMS);
+        assert_eq!(error.message, "File does not exist: C:/missing.txt");
+        assert!(error.data.is_none());
+    }
 
     #[test]
     fn configured_executor_is_the_server_search_source_for_serial_mid_and_maximum_p() {

--- a/src/server.rs
+++ b/src/server.rs
@@ -279,7 +279,12 @@ impl FastCtxServer {
 impl ServerHandler for FastCtxServer {
     fn get_info(&self) -> ServerInfo {
         self.activity.touch();
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+        ServerInfo::new(
+            ServerCapabilities::builder()
+                .enable_tools()
+                .enable_resources()
+                .build(),
+        )
             .with_server_info(Implementation::new(
                 env!("CARGO_PKG_NAME"),
                 env!("CARGO_PKG_VERSION"),
@@ -352,6 +357,14 @@ impl ServerHandler for FastCtxServer {
     /// This handles the misrouted `resources/read` calls that some hosts produce
     /// even when the server does not advertise the `resources` capability. Remote
     /// authorities, non-file schemes, queries, and fragments are rejected.
+    ///
+    /// **Token budget protection**: this goes through `run_blocking` with
+    /// `READ_TOKEN_BUDGET_ENV`, the same path as `inspect_local_file`. This
+    /// ensures the response respects the configured output budget and triggers
+    /// the guarded-burst stub when the response would exhaust the turn's shared
+    /// output pool — preventing context-window blowout via `resources/read`
+    /// (#24). Without this, a large file read through `resources/read` would
+    /// bypass the budget and dump unlimited content into the model's context.
     fn read_resource(
         &self,
         request: ReadResourceRequestParams,
@@ -371,62 +384,57 @@ impl ServerHandler for FastCtxServer {
             )
         })?;
 
-        // Acquire a file-operation permit so resource reads compete fairly with
-        // `inspect_local_file` calls under the same concurrency limit.
-        let permit = Arc::clone(&self.file_permits)
-            .acquire_owned()
-            .await
-            .map_err(|_| {
-                ErrorData::internal_error(
-                    "The blocking-operation limiter is unavailable for resources/read.",
-                    None,
-                )
-            })?;
+        // Reuse the same session, permits, and budget system as inspect_local_file.
+        // run_blocking acquires a file-permit, activates the session, applies the
+        // guarded-burst budget ceiling, and converts to CallToolResult. We then
+        // convert CallToolResult back to ReadResourceResult.
+        let session = Arc::clone(&self.session);
+        let permits = Arc::clone(&self.file_permits);
+        let shell = self.shell.clone();
+        let result = run_blocking(
+            session,
+            permits,
+            READ_TOKEN_BUDGET_ENV,
+            move || shell.background_status(None),
+            BudgetRetry::Safe,
+            move || {
+                read_file(ReadRequest {
+                    file_path: Some(file_path),
+                    files: None,
+                    offset: None,
+                    limit: None,
+                    pages: None,
+                    pdf_mode: None,
+                    encoding: None,
+                    view: None,
+                })
+            },
+        )
+        .await;
 
-        let response = tokio::task::spawn_blocking(move || {
-            let _permit = permit;
-            read_file(ReadRequest {
-                file_path: Some(file_path),
-                files: None,
-                offset: None,
-                limit: None,
-                pages: None,
-                pdf_mode: None,
-                encoding: None,
-                view: None,
-            })
-        })
-        .await
-        .map_err(|error| {
-            ErrorData::internal_error(
-                format!("Internal resource read failure: {error}"),
-                None,
-            )
-        })?;
-
-        resource_read_result(uri, response)
+        call_tool_result_to_resource_result(uri, result)
     }
 }
 
-/// Converts a `ToolResponse` from `read_file` into an MCP `ReadResourceResult`.
+/// Converts a `CallToolResult` from `run_blocking` into an MCP `ReadResourceResult`.
 ///
-/// Text blocks become `ResourceContents::text` and image blocks become
+/// Text content blocks become `ResourceContents::text` and image blocks become
 /// `ResourceContents::blob` with the appropriate MIME type. When the tool
 /// response is an error, it is surfaced as an `invalid_params` protocol error
 /// so the host can display a meaningful message rather than an opaque failure.
-fn resource_read_result(
+fn call_tool_result_to_resource_result(
     uri: String,
-    response: crate::model::ToolResponse,
+    result: CallToolResult,
 ) -> Result<ReadResourceResult, ErrorData> {
-    use crate::model::{ImageDetail, ToolContent, ToolResponse};
+    use rmcp::model::ContentBlock;
 
-    let ToolResponse { content, is_error } = response;
-    if is_error {
-        let message = content
+    if result.is_error == Some(true) {
+        let message = result
+            .content
             .into_iter()
             .filter_map(|block| match block {
-                ToolContent::Text(text) => Some(text),
-                ToolContent::Image { .. } => None,
+                ContentBlock::Text(text) => Some(text.text),
+                _ => None,
             })
             .collect::<Vec<_>>()
             .join("\n");
@@ -440,17 +448,22 @@ fn resource_read_result(
         ));
     }
 
-    let contents = content
+    let contents = result
+        .content
         .into_iter()
         .map(|block| match block {
-            ToolContent::Text(text) => ResourceContents::text(text, uri.clone()),
-            ToolContent::Image {
-                data,
-                mime_type,
-                detail,
-            } => {
-                let contents = ResourceContents::blob(data, uri.clone()).with_mime_type(mime_type);
-                if detail == Some(ImageDetail::High) {
+            ContentBlock::Text(text) => {
+                ResourceContents::text(text.text, uri.clone())
+            }
+            ContentBlock::Image(image) => {
+                let contents = ResourceContents::blob(image.data, uri.clone())
+                    .with_mime_type(image.mime_type);
+                if image
+                    ._meta
+                    .as_ref()
+                    .and_then(|meta| meta.0.get("codex/imageDetail"))
+                    .is_some_and(|v| v == "high")
+                {
                     let mut meta = Meta::new();
                     meta.0.insert(
                         "codex/imageDetail".to_string(),
@@ -461,6 +474,10 @@ fn resource_read_result(
                     contents
                 }
             }
+            _ => ResourceContents::text(
+                "Unsupported content block type in resource read.".to_string(),
+                uri.clone(),
+            ),
         })
         .collect();
 
@@ -469,31 +486,31 @@ fn resource_read_result(
 
 #[cfg(test)]
 mod tests {
-    use super::{FastCtxServer, ServerOptions, SharedRuntime, resource_read_result};
+    use super::{FastCtxServer, ServerOptions, SharedRuntime, call_tool_result_to_resource_result};
     use crate::file_executor::GrepGlobExecutor;
-    use crate::model::{ImageDetail, ToolContent, ToolResponse};
     use crate::search_parallelism::MAX_SEARCH_PARALLELISM;
-    use rmcp::model::ErrorCode;
+    use rmcp::model::{CallToolResult, ContentBlock, ErrorCode, ImageContent, Meta};
     use std::sync::Arc;
 
     #[test]
-    fn resource_read_result_preserves_text_and_image_content() {
-        let result = resource_read_result(
+    fn call_tool_result_to_resource_preserves_text_and_image() {
+        let mut image_meta = Meta::new();
+        image_meta.0.insert(
+            "codex/imageDetail".to_string(),
+            serde_json::Value::String("high".to_string()),
+        );
+        let result = call_tool_result_to_resource_result(
             "file:///C:/notes.txt".to_string(),
-            ToolResponse {
-                content: vec![
-                    ToolContent::Text("1\tline".to_string()),
-                    ToolContent::Image {
-                        data: "aW1hZ2U=".to_string(),
-                        mime_type: "image/png".to_string(),
-                        detail: Some(ImageDetail::High),
-                    },
-                ],
-                is_error: false,
-            },
+            CallToolResult::success(vec![
+                ContentBlock::Text(rmcp::model::TextContent::new("1\tline")),
+                ContentBlock::Image(
+                    ImageContent::new("aW1hZ2U=".to_string(), "image/png".to_string())
+                        .with_meta(image_meta),
+                ),
+            ]),
         )
         .unwrap();
-        let value = serde_json::to_value(result).unwrap();
+        let value = serde_json::to_value(&result).unwrap();
         assert_eq!(value["contents"][0]["uri"], "file:///C:/notes.txt");
         assert_eq!(value["contents"][0]["mimeType"], "text/plain");
         assert_eq!(value["contents"][0]["text"], "1\tline");
@@ -504,10 +521,12 @@ mod tests {
     }
 
     #[test]
-    fn resource_read_result_surfaces_tool_errors_as_protocol_errors() {
-        let error = resource_read_result(
+    fn call_tool_result_to_resource_surfaces_errors() {
+        let error = call_tool_result_to_resource_result(
             "file:///C:/missing.txt".to_string(),
-            ToolResponse::error("File does not exist: C:/missing.txt"),
+            CallToolResult::error(vec![ContentBlock::Text(
+                rmcp::model::TextContent::new("File does not exist: C:/missing.txt"),
+            )]),
         )
         .unwrap_err();
         assert_eq!(error.code, ErrorCode::INVALID_PARAMS);


### PR DESCRIPTION
## Summary

FastCtx is a tool-only MCP server by design, but some MCP hosts (notably Codex Desktop / CLI) inject a generic `read_mcp_resource` tool for **every** configured server regardless of whether the server advertises the `resources` capability. When the model sees that tool but has no valid server name or URI template to fill, it fabricates placeholders like `server="?"`, `uri="?"` — producing chains of failed calls that never reach the server (tracked in #18, #26).

The 0.2.2 approach (override `resources/*` to reject uniformly) backfired: a *failure* makes the model retry with a different invented `server` argument rather than switch to the correct `inspect_local_file` tool — users reported chains of invented server names.

This PR takes the **opposite approach**: make resources genuinely work so the model has a real target instead of a failure to retry against, **and** protect against the context-window blowout that resource reads could cause without budget enforcement.

## Changes

### Commit 1: `feat(server): publish resource templates and accept file:// reads`

1. **`list_resource_templates`** — returns a `file:///{path}` template with a description teaching the model the absolute-path format. This gives the model a valid URI pattern to fill, eliminating the `?` placeholder root cause. (**Not in PR #21.**)

2. **`read_resource`** — accepts `file:///` URI or plain absolute path, reads the file by reusing `read_file`.

3. **`list_resources`** — stays on the rmcp default (empty list); the template is the single entry point.

### Commit 2: `feat(server): budget-protected resource reads, advertise resources, fix glob schema`

4. **Token budget protection for `resources/read`** (#24):
   `read_resource` now goes through `run_blocking` with `READ_TOKEN_BUDGET_ENV` — the same path as `inspect_local_file`. This ensures the response respects the configured output budget and triggers the guarded-burst stub when the response would exhaust the turn's shared output pool. Without this, a large file read through `resources/read` could **bypass the budget and dump unlimited content into the model's context window** — the exact problem reported in #24.

5. **Advertise `resources` capability**:
   `get_info` now calls `enable_resources()` on `ServerCapabilities`. This tells hosts that FastCtx genuinely supports resources, so they can route `read_mcp_resource` calls correctly instead of treating the server as tool-only and still injecting the generic tool as a fallback.

6. **Updated AGENTS.md guidance to match new behavior**:
   The old guidance said "never use `file://` URI" and "resources always fail". Now that `resources/read` is genuinely supported, the guidance is updated to a layered recommendation: prefer `inspect_local_file` for batch reads, offset paging, and encoding control; `resources/read` with `file:///` URIs is accepted as a compatibility path.

7. **Fix glob `sort` field schema type** (#25):
   The `Option<SortMode>` field on `GlobRequest` was rejected by strict LLM APIs (Gemini 3.1 Pro) because the JSON schema lacked an explicit `type` field. Added a `sort_field_schema` function that emits a proper `{type: string, enum: [path, modified]}` schema via `#[schemars(with = ...)]`.

## Relationship to PR #21

PR #21 (by @foryourhealth111-pixel) handles misrouted `resources/read` calls but **keeps `resources/templates/list` rejected** (method-not-found) and **does not go through `run_blocking`** — it spawns a blocking task directly, bypassing the token budget system. This means:
- The model still has no valid URI template to fill → `?` placeholder persists
- Large file reads via `resources/read` can blow out the context window (#24)

This PR addresses both: it publishes a template (root cause fix) and routes `read_resource` through `run_blocking` (budget protection). The unit tests are adapted from PR #21's test cases.

## What this optimizes

| Aspect | Before (v0.2.5) | After |
|---|---|---|
| `resources/templates/list` | `-32601` method-not-found | Returns `file:///{path}` template |
| `resources/read` | `-32601` method-not-found | Reads file via `run_blocking` (budget-protected) |
| Token budget on resource reads | N/A (rejected) | Enforced via `READ_TOKEN_BUDGET_ENV` + guarded-burst stub |
| Resources capability | Not advertised | Advertised via `enable_resources()` |
| Model behavior with `read_mcp_resource` | Fabricates `server="?"`, `uri="?"` | Has valid template to fill |
| Glob `sort` field schema | Missing `type` → 400 from strict APIs | Explicit `{type: string, enum: [...]}` |
| AGENTS.md guidance | "Never use file:// URI" | Layered: prefer direct tool, file:/// accepted |

## Validation

- `cargo fmt --check`
- `cargo clippy --locked --no-default-features --all-targets -- -D warnings`
- Unit tests for `call_tool_result_to_resource_result` covering text/image content preservation and error surfacing
- Manual stdio MCP probe (JSON-RPC `resources/templates/list` + `resources/read` with `file:///` URI) — verified on Windows with a locally compiled 0.2.5 binary

## Same-name product search

No exact same-name product exists on GitHub. Functionally similar MCP servers include `smart-read` (token-efficient, zero-dependency), `codeindex-mcp` (Go, in-memory full-text), and `CodeToolsMcp` (Claude Code style). FastCtx is the only Rust implementation with a persistent control-center architecture and background job management.

Refs #18, #24, #25, #26.
