### PR TITLE
fix: publish explicit glob enum schemas

### DIFF
--- a/src/glob_tool.rs
+++ b/src/glob_tool.rs
@@ -49,6 +49,28 @@ pub enum SortMode {
     Modified,
 }
 
+fn string_enum_schema(values: &[&str]) -> schemars::Schema {
+    let mut map = serde_json::Map::new();
+    map.insert("type".into(), "string".into());
+    map.insert(
+        "enum".into(),
+        values
+            .iter()
+            .map(|value| serde_json::Value::String((*value).to_string()))
+            .collect::<Vec<_>>()
+            .into(),
+    );
+    schemars::Schema::from(map)
+}
+
+fn filter_mode_schema(_: &mut schemars::SchemaGenerator) -> schemars::Schema {
+    string_enum_schema(&["project", "all"])
+}
+
+fn sort_mode_schema(_: &mut schemars::SchemaGenerator) -> schemars::Schema {
+    string_enum_schema(&["path", "modified"])
+}
+
 /// Parameters for the glob tool.
 #[derive(Clone, Debug, Deserialize, JsonSchema)]
 pub struct GlobRequest {
@@ -60,8 +82,10 @@ pub struct GlobRequest {
     ))]
     pub path: Option<String>,
     /// "project" respects .gitignore/.ignore, includes hidden files, excludes .git (same traversal as grep). "all" disables all filtering.
+    #[schemars(schema_with = "filter_mode_schema")]
     pub filter_mode: Option<FilterMode>,
     /// "path" = byte-order path sort. "modified" = most recently modified first.
+    #[schemars(schema_with = "sort_mode_schema")]
     pub sort: Option<SortMode>,
     /// Skip the first N results — for paging.
     pub offset: Option<usize>,

--- a/tests/server_contract.rs
+++ b/tests/server_contract.rs
@@ -70,6 +70,34 @@ fn all_nine_tools_publish_explicit_three_hint_annotations() {
 }
 
 #[test]
+fn glob_enum_options_publish_explicit_string_schemas() {
+    let tools = FastCtxServer::new().tool_definitions();
+    let glob = tools.iter().find(|tool| tool.name == "glob").unwrap();
+
+    assert_string_enum_schema(
+        &glob.input_schema["properties"]["filter_mode"],
+        &["project", "all"],
+    );
+    assert_string_enum_schema(
+        &glob.input_schema["properties"]["sort"],
+        &["path", "modified"],
+    );
+}
+
+fn assert_string_enum_schema(schema: &Value, expected_values: &[&str]) {
+    assert_eq!(schema["type"], "string", "{schema}");
+    assert_eq!(
+        schema["enum"]
+            .as_array()
+            .expect("enum schema should list accepted string values")
+            .iter()
+            .map(|value| value.as_str().unwrap())
+            .collect::<Vec<_>>(),
+        expected_values
+    );
+}
+
+#[test]
 fn shell_and_replace_tool_descriptions_and_schemas_match_the_frozen_contract() {
     let tools = FastCtxServer::with_options(ServerOptions::all()).tool_definitions();
     let shell = tools


### PR DESCRIPTION
## Summary
- publish explicit string enum schemas for glob `filter_mode` and `sort` options
- add a server contract test to guard strict-provider compatibility

Fixes #25.

## Validation
- `cargo fmt --check`
- `cargo test glob_enum_options_publish_explicit_string_schemas --test server_contract`
- `cargo test --test server_contract`
- `cargo clippy --all-targets -- -D warnings`