### PR TITLE
fix: reject unknown file-tool target fields

### DIFF
--- a/src/control/agents.rs
+++ b/src/control/agents.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 const BEGIN_MARKER: &str = "<!-- fastctx:begin -->";
 const END_MARKER: &str = "<!-- fastctx:end -->";
-pub(crate) const MANAGED_SECTION_CONTRACT_ID: &str = "guidance-v4";
+pub(crate) const MANAGED_SECTION_CONTRACT_ID: &str = "guidance-v5";
 const LEGACY_BEGIN_MARKER: &str = "<!-- fastread:begin -->";
 const LEGACY_END_MARKER: &str = "<!-- fastread:end -->";
 const LEGACY_FASTREAD_SECTION: &str = concat!(
@@ -147,6 +147,8 @@ const V024_READ_TOOL_NAME_SHELL_GUIDANCE: &str = V022_RESOURCE_ROUTING_SHELL_GUI
 /// One byte-frozen managed block from a superseded release.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum KnownLegacyGuidance {
+    /// 0.2.5, superseded when file-tool target fields became explicit host guidance.
+    TargetFields,
     /// 0.2.2/0.2.3, whose prohibition named the very resource tools it steered away from.
     ResourceRouting,
     /// 0.2.4, superseded when the file-inspection tool was renamed away from `read`.
@@ -155,30 +157,45 @@ pub(crate) enum KnownLegacyGuidance {
 
 impl KnownLegacyGuidance {
     /// Every superseded release this build still recognises, newest first.
-    pub(crate) const ALL: [Self; 2] = [Self::ReadToolName, Self::ResourceRouting];
+    pub(crate) const ALL: [Self; 3] = [
+        Self::TargetFields,
+        Self::ReadToolName,
+        Self::ResourceRouting,
+    ];
 
-    fn guidance(self) -> (&'static str, &'static str) {
+    fn frozen_guidance(self) -> Option<(&'static str, &'static str)> {
         match self {
-            Self::ResourceRouting => (
+            Self::TargetFields => None,
+            Self::ResourceRouting => Some((
                 V022_RESOURCE_ROUTING_FILE_GUIDANCE,
                 V022_RESOURCE_ROUTING_SHELL_GUIDANCE,
-            ),
-            Self::ReadToolName => (
+            )),
+            Self::ReadToolName => Some((
                 V024_READ_TOOL_NAME_FILE_GUIDANCE,
                 V024_READ_TOOL_NAME_SHELL_GUIDANCE,
-            ),
+            )),
         }
     }
 
     /// Rebuilds this release's exact managed block for the optional shell group.
     pub(crate) fn section(self, fastshell_enabled: bool) -> String {
-        let (file_guidance, shell_guidance) = self.guidance();
         let mut output = String::from(BEGIN_MARKER);
         output.push('\n');
-        output.push_str(file_guidance);
-        if fastshell_enabled {
+        if self == Self::TargetFields {
+            output.push_str(FILE_GUIDANCE_PREFIX);
+            output.push_str(crate::model_guidance::LOCAL_FILE_ROUTE_GUIDANCE);
             output.push('\n');
-            output.push_str(shell_guidance);
+            output.push_str(FILE_GUIDANCE_SUFFIX);
+            if fastshell_enabled {
+                output.push('\n');
+                output.push_str(SHELL_GUIDANCE);
+            }
+        } else if let Some((file_guidance, shell_guidance)) = self.frozen_guidance() {
+            output.push_str(file_guidance);
+            if fastshell_enabled {
+                output.push('\n');
+                output.push_str(shell_guidance);
+            }
         }
         output.push_str(END_MARKER);
         output
@@ -228,6 +245,8 @@ pub fn section(fastshell_enabled: bool) -> String {
     output.push('\n');
     output.push_str(FILE_GUIDANCE_PREFIX);
     output.push_str(crate::model_guidance::LOCAL_FILE_ROUTE_GUIDANCE);
+    output.push('\n');
+    output.push_str(crate::model_guidance::LOCAL_FILE_TARGET_FIELD_GUIDANCE);
     output.push('\n');
     output.push_str(FILE_GUIDANCE_SUFFIX);
     if fastshell_enabled {
@@ -457,4 +476,29 @@ fn marker_range(
     }
     let end = end_start + end_marker.len();
     Ok(Some((start, end)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        KnownLegacyGuidance, ManagedSectionState, classify_managed_section,
+        refresh_known_legacy_section, section,
+    };
+
+    #[test]
+    fn v025_guidance_is_recognized_and_refreshes_to_explicit_target_fields() {
+        for fastshell_enabled in [false, true] {
+            let legacy = KnownLegacyGuidance::TargetFields.section(fastshell_enabled);
+            assert_eq!(
+                classify_managed_section(legacy.as_bytes(), fastshell_enabled),
+                ManagedSectionState::KnownLegacy
+            );
+            let refreshed = refresh_known_legacy_section(legacy.as_bytes(), fastshell_enabled)
+                .expect("v0.2.5 guidance should refresh");
+            assert_eq!(refreshed, section(fastshell_enabled).into_bytes());
+            let refreshed = String::from_utf8(refreshed).unwrap();
+            assert!(refreshed.contains("`inspect_local_file` uses `file_path`"));
+            assert!(refreshed.contains("`grep`, `glob`, and `replace` use `path`"));
+        }
+    }
 }

--- a/src/edit/mod.rs
+++ b/src/edit/mod.rs
@@ -16,6 +16,7 @@ use std::sync::{Arc, Mutex, Weak};
 
 /// Parameters for deterministic batch replacement across one file or a project tree.
 #[derive(Clone, Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct ReplaceRequest {
     /// The regular expression to replace (Rust regex; escape literal braces).
     pub pattern: String,

--- a/src/glob_tool.rs
+++ b/src/glob_tool.rs
@@ -51,6 +51,7 @@ pub enum SortMode {
 
 /// Parameters for the glob tool.
 #[derive(Clone, Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct GlobRequest {
     /// Globs to match files, e.g. ["**/*.rs", "!tests/**"]. A leading `!` excludes and always wins; negative-only patterns list every other file.
     // Published as a plain string array rather than the string-or-array union the type

--- a/src/grep_tool.rs
+++ b/src/grep_tool.rs
@@ -64,6 +64,7 @@ pub enum OutputMode {
 
 /// Parameters for the grep tool.
 #[derive(Clone, Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct GrepRequest {
     /// The regular expression to search for (Rust regex syntax; escape literal braces like `interface\{\}`).
     pub pattern: String,

--- a/src/model_guidance.rs
+++ b/src/model_guidance.rs
@@ -6,6 +6,12 @@ pub(crate) const LOCAL_FILE_ROUTE_GUIDANCE: &str = concat!(
     "local reference is URI-shaped; pass the equivalent plain absolute filesystem path."
 );
 
+/// Target-field distinction emitted into the FastCtx-owned host guidance block.
+pub(crate) const LOCAL_FILE_TARGET_FIELD_GUIDANCE: &str = concat!(
+    "Target fields are tool-specific: `inspect_local_file` uses `file_path`, while\n",
+    "`grep`, `glob`, and `replace` use `path`; never substitute these field names."
+);
+
 /// Shared path-shape contract used by every file tool's path field.
 pub(crate) const LOCAL_PATH_INPUT_GUIDANCE: &str = concat!(
     "Plain absolute local filesystem path. When the source reference is URI-shaped, ",

--- a/tests/cli_contract.rs
+++ b/tests/cli_contract.rs
@@ -250,6 +250,14 @@ fn apply_status_and_unapply_cover_both_shell_states() {
         assert_eq!(agents.contains("### Shell commands"), fastshell);
         assert!(agents.contains("### Batch replacement"), "{agents}");
         assert!(agents.contains("FastCtx's `replace`"), "{agents}");
+        assert!(
+            agents.contains("`inspect_local_file` uses `file_path`"),
+            "{agents}"
+        );
+        assert!(
+            agents.contains("`grep`, `glob`, and `replace` use `path`"),
+            "{agents}"
+        );
         for removed in ["copy", "cut", "paste", "clips", "drop"] {
             assert!(!agents.contains(&format!("`{removed}`")));
         }

--- a/tests/server_contract.rs
+++ b/tests/server_contract.rs
@@ -232,6 +232,35 @@ fn glob_pattern_parameters_accept_both_the_advertised_array_and_a_bare_string() 
 }
 
 #[test]
+fn file_tool_requests_reject_unknown_target_fields() {
+    let grep = serde_json::from_value::<fastctx::grep_tool::GrepRequest>(serde_json::json!({
+        "pattern": "needle",
+        "file_path": "/tmp/file.txt",
+    }))
+    .unwrap_err()
+    .to_string();
+    assert!(grep.contains("unknown field `file_path`"), "{grep}");
+
+    let glob = serde_json::from_value::<fastctx::glob_tool::GlobRequest>(serde_json::json!({
+        "pattern": ["**/*.rs"],
+        "file_path": "/tmp",
+    }))
+    .unwrap_err()
+    .to_string();
+    assert!(glob.contains("unknown field `file_path`"), "{glob}");
+
+    let replace = serde_json::from_value::<fastctx::edit::ReplaceRequest>(serde_json::json!({
+        "pattern": "needle",
+        "replacement": "thread",
+        "path": "/tmp/file.txt",
+        "file_path": "/tmp/other.txt",
+    }))
+    .unwrap_err()
+    .to_string();
+    assert!(replace.contains("unknown field `file_path`"), "{replace}");
+}
+
+#[test]
 fn shell_and_replace_tool_descriptions_and_schemas_match_the_frozen_contract() {
     let tools = FastCtxServer::with_options(ServerOptions::all()).tool_definitions();
     let shell = tools


### PR DESCRIPTION
## Summary

- reject unknown target fields for `grep`, `glob`, and `replace` instead of silently ignoring them
- document that `inspect_local_file` uses `file_path`, while the other file tools use `path`
- migrate the managed guidance contract from v0.2.5 to the new explicit target-field wording

## Problem

A call shaped like this is accepted today even though `grep` has no `file_path` parameter:

```json
{"pattern":"needle","file_path":"X:/large/repo/file.txt"}
```

Serde ignores the unknown field, so the optional `path` remains absent and the search falls back to the session working directory. In a large checkout this can turn a one-file lookup into a long full-tree scan and eventually hit the host tool timeout.

This change makes the call fail at parameter deserialization and keeps the managed `AGENTS.md` guidance explicit about the distinct target fields.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --test server_contract` (9 passed)
- `cargo test --test cli_contract` (8 passed)
- `cargo test -- --skip thin_proxy_stays_within_a_measured_memory_and_thread_ceiling_after_real_tools` (passed)
- release MCP reproduction: malformed `file_path` is rejected in under one second; a correct single-file `path` call succeeds

`cargo test` without the skip has one environment-sensitive baseline failure on Windows: `thin_proxy_stays_within_a_measured_memory_and_thread_ceiling_after_real_tools` observes 9 retained proxy threads. The same exact test fails with the same 9-thread observation on an unmodified `origin/main` checkout at `e9b80dd`, so it is not introduced by this change.