### PR TITLE
fix(shell,read): distinguish killed runs from pageable partials; count batch entries honestly

### DIFF
--- a/src/background_status.rs
+++ b/src/background_status.rs
@@ -169,7 +169,10 @@ fn decorate_response(response: ToolResponse, outcome: ResponseReservationOutcome
 fn insert_status_line(text: &mut String, status: &str) {
     let terminal_start = text.rfind('\n').map_or(0, |index| index.saturating_add(1));
     let last = &text[terminal_start..];
-    if last.starts_with("(Complete:") || last.starts_with("(Partial:") {
+    if last.starts_with("(Complete:")
+        || last.starts_with("(Partial:")
+        || last.starts_with("(Killed:")
+    {
         if terminal_start == 0 {
             *text = format!("{status}\n{text}");
         } else {

--- a/src/read_tool/batch.rs
+++ b/src/read_tool/batch.rs
@@ -148,6 +148,14 @@ fn pack_entries(entries: Vec<BatchReadEntry>, budget: TokenBudget) -> ToolRespon
         .map(Some)
         .collect::<Vec<_>>();
     let mut segments = Vec::new();
+    // How many leading entries this response has fully settled (content shown in
+    // full or an inline problem reported). A budget break stops the loop, so every
+    // entry after the break was never attempted and must not be counted against
+    // the ones already delivered (#32).
+    let mut delivered = 0_usize;
+    // The index whose content is only partially shown, if any; it stays in the
+    // continuation array but counts as processed for the tally.
+    let mut partially_shown = false;
 
     for (index, entry) in entries.iter().enumerate() {
         let prepared = prepare_entry(entry, budget.value);
@@ -156,7 +164,15 @@ fn pack_entries(entries: Vec<BatchReadEntry>, budget: TokenBudget) -> ToolRespon
                 let segment = format!("=== {} ===\n{message}", prepared.path);
                 let mut proposed = progress.clone();
                 proposed[index] = None;
-                if !candidate_fits(&segments, &segment, &proposed, total, budget.value) {
+                if !candidate_fits(
+                    &segments,
+                    &segment,
+                    &proposed,
+                    total,
+                    delivered,
+                    partially_shown,
+                    budget.value,
+                ) {
                     if segments.is_empty() {
                         return budget_too_small(budget);
                     }
@@ -164,6 +180,7 @@ fn pack_entries(entries: Vec<BatchReadEntry>, budget: TokenBudget) -> ToolRespon
                 }
                 segments.push(segment);
                 progress = proposed;
+                delivered += 1;
             }
             PreparedOutcome::Content(content) => {
                 let shown = largest_fitting_prefix(
@@ -187,13 +204,21 @@ fn pack_entries(entries: Vec<BatchReadEntry>, budget: TokenBudget) -> ToolRespon
                 progress[index] = proposed;
                 segments.push(segment);
                 if shown < content.lines.len() || !content.slice_complete {
+                    partially_shown = true;
                     break;
                 }
+                delivered += 1;
             }
         }
     }
 
-    ToolResponse::text(render_response(&segments, &progress, total))
+    ToolResponse::text(render_response(
+        &segments,
+        &progress,
+        total,
+        delivered,
+        partially_shown,
+    ))
 }
 
 fn prepare_entry(entry: &BatchReadEntry, collection_budget: usize) -> PreparedEntry {
@@ -299,7 +324,17 @@ fn largest_fitting_prefix(
         let mut proposed = progress.to_vec();
         proposed[index] = progress_after(entry, content, shown);
         let segment = content_segment(path, content, shown);
-        candidate_fits(segments, &segment, &proposed, total, budget)
+        // During the binary search this entry is by definition the partially
+        // shown one; the delivered count comes from the caller via `segments`.
+        candidate_fits(
+            segments,
+            &segment,
+            &proposed,
+            total,
+            segments.len(),
+            true,
+            budget,
+        )
     };
 
     // Probing the whole slice first is what makes the search sound: dropping the last line
@@ -338,13 +373,20 @@ fn progress_after(
     if last >= content.total_lines {
         return None;
     }
+    // The continuation's limit counts the requested window, not the file: the next
+    // call should read exactly the lines this request promised but did not show.
+    // A limit that already ran past EOF carries no remainder, so it is dropped —
+    // an explicit cap of "whatever is left" is what an omitted limit already means.
+    let remaining_lines = content.total_lines - last;
+    let limit = entry.limit.and_then(|limit| {
+        let requested_end = content.first.saturating_add(limit.saturating_sub(1));
+        let value = requested_end.min(content.total_lines) - last;
+        (value > 0 && value < remaining_lines).then_some(value)
+    });
     Some(ContinuationEntry {
         path: entry.path.clone(),
         offset: Some(last.saturating_add(1)),
-        limit: entry
-            .limit
-            .and_then(|limit| limit.checked_sub(shown))
-            .filter(|remaining| *remaining > 0),
+        limit,
         encoding: entry.encoding.clone(),
     })
 }
@@ -373,19 +415,29 @@ fn candidate_fits(
     candidate: &str,
     progress: &[Option<ContinuationEntry>],
     total: usize,
+    delivered: usize,
+    partially_shown: bool,
     budget: usize,
 ) -> bool {
     let mut proposed = segments.to_vec();
     proposed.push(candidate.to_string());
-    estimate_tokens(&render_response(&proposed, progress, total)) <= budget
+    estimate_tokens(&render_response(
+        &proposed,
+        progress,
+        total,
+        delivered,
+        partially_shown,
+    )) <= budget
 }
 
 fn render_response(
     segments: &[String],
     progress: &[Option<ContinuationEntry>],
     total: usize,
+    delivered: usize,
+    partially_shown: bool,
 ) -> String {
-    let terminal = batch_terminal(progress, total);
+    let terminal = batch_terminal(progress, total, delivered, partially_shown);
     if segments.is_empty() {
         terminal
     } else {
@@ -393,15 +445,32 @@ fn render_response(
     }
 }
 
-fn batch_terminal(progress: &[Option<ContinuationEntry>], total: usize) -> String {
+fn batch_terminal(
+    progress: &[Option<ContinuationEntry>],
+    total: usize,
+    delivered: usize,
+    partially_shown: bool,
+) -> String {
     let pending = progress.iter().flatten().collect::<Vec<_>>();
     if pending.is_empty() {
         let noun = if total == 1 { "entry" } else { "entries" };
         return format!("(Complete: {total} {noun} processed.)");
     }
+    // `delivered` counts fully settled entries; a partially shown entry counts as
+    // processed too, because its continuation carries the exact resume point. The
+    // remainder of `total` was never attempted — the budget broke before it — so
+    // saying "0 of N" for them would tell the model its delivered content did not
+    // happen (#32).
+    let processed = if partially_shown {
+        delivered + 1
+    } else {
+        delivered
+    };
+    let noun = if processed == 1 { "entry" } else { "entries" };
     let json = serde_json::to_string(&pending).expect("continuation entries serialize");
-    let processed = total - pending.len();
-    format!("(Partial: {processed} of {total} entries processed. Continue with files={json}.)")
+    format!(
+        "(Partial: {processed} {noun} in progress, {total} requested. Continue with files={json}.)"
+    )
 }
 
 fn budget_too_small(budget: TokenBudget) -> ToolResponse {

--- a/src/server_support.rs
+++ b/src/server_support.rs
@@ -219,6 +219,7 @@ fn guarded_response_metadata(response: &ToolResponse) -> String {
                 let line = line.trim();
                 line.starts_with("(Complete:")
                     || line.starts_with("(Partial:")
+                    || line.starts_with("(Killed:")
                     || line.starts_with("Script running with cell ID")
             })
             .map(str::trim)

--- a/src/shell/output.rs
+++ b/src/shell/output.rs
@@ -77,13 +77,13 @@ pub(crate) fn validate_run_budget(timeout_ms: u64) -> Result<TokenBudget, String
             i32::MIN
         ),
         format!(
-            "(Partial: timed out after {timeout_ms} ms and the process tree was killed; no output captured. Increase timeout_ms or use run_background.)"
+            "(Killed: timed out after {timeout_ms} ms and the process tree was killed; no output captured. Re-run with a larger timeout_ms or use run_background.)"
         ),
         format!(
-            "(Partial: timed out after {timeout_ms} ms and the process tree was killed; {maximum} lines captured. Increase timeout_ms or use run_background.)"
+            "(Killed: timed out after {timeout_ms} ms and the process tree was killed; {maximum} lines captured. Re-run with a larger timeout_ms or use run_background.)"
         ),
         format!(
-            "(Partial: timed out after {timeout_ms} ms and the process tree was killed; showing the first 0 and last 0 of {maximum} captured lines. Increase timeout_ms or use run_background.)"
+            "(Killed: timed out after {timeout_ms} ms and the process tree was killed; showing the first 0 and last 0 of {maximum} captured lines. Re-run with a larger timeout_ms or use run_background.)"
         ),
         ring_loss,
     ];
@@ -208,10 +208,10 @@ fn full_terminal(
 ) -> String {
     match timeout_ms {
         Some(timeout) if total == 0 => format!(
-            "(Partial: timed out after {timeout} ms and the process tree was killed; no output captured. Increase timeout_ms or use run_background.)"
+            "(Killed: timed out after {timeout} ms and the process tree was killed; no output captured. Re-run with a larger timeout_ms or use run_background.)"
         ),
         Some(timeout) => format!(
-            "(Partial: timed out after {timeout} ms and the process tree was killed; {total} {} captured. Increase timeout_ms or use run_background.)",
+            "(Killed: timed out after {timeout} ms and the process tree was killed; {total} {} captured. Re-run with a larger timeout_ms or use run_background.)",
             plural(total, "line", "lines")
         ),
         None if total == 0 => format!("(Complete: exited {exit_code}; no output.)"),
@@ -238,7 +238,7 @@ fn window_terminal(
             "(Partial: showing the first {first} and last {last} of {total} lines; exited {exit_code}.)"
         ),
         Some(timeout) => format!(
-            "(Partial: timed out after {timeout} ms and the process tree was killed; showing the first {first} and last {last} of {total} captured lines. Increase timeout_ms or use run_background.)"
+            "(Killed: timed out after {timeout} ms and the process tree was killed; showing the first {first} and last {last} of {total} captured lines. Re-run with a larger timeout_ms or use run_background.)"
         ),
     }
 }

--- a/src/shell_server.rs
+++ b/src/shell_server.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 impl FastCtxServer {
     #[tool(
         name = "run",
-        description = "Use for non-interactive local CLI work, including Git, build/test tools,\npackage managers, database CLIs, and project scripts. Commands run with bash\n(Git Bash on Windows; system bash elsewhere) and return merged stdout+stderr\nwith the exit code. Write POSIX bash — never PowerShell. There is no TTY or\nstdin; use flags like -y or --no-edit. A non-zero exit code is a normal\nresult, not an error. Oversized output is truncated; for the full output,\nredirect it to a file (command > file 2>&1) and page that file with\ninspect_local_file.\nDefault timeout 120000 ms, ceiling 240000 — start anything that may outlast\nit with run_background. If output looks garbled (U+FFFD), pass encoding\n(e.g. \"gbk\"). The last line states Complete or Partial.",
+        description = "Use for non-interactive local CLI work, including Git, build/test tools,\npackage managers, database CLIs, and project scripts. Commands run with bash\n(Git Bash on Windows; system bash elsewhere) and return merged stdout+stderr\nwith the exit code. Write POSIX bash — never PowerShell. There is no TTY or\nstdin; use flags like -y or --no-edit. A non-zero exit code is a normal\nresult, not an error. Oversized output is truncated; for the full output,\nredirect it to a file (command > file 2>&1) and page that file with\ninspect_local_file.\nDefault timeout 120000 ms, ceiling 240000 — start anything that may outlast\nit with run_background. If output looks garbled (U+FFFD), pass encoding\n(e.g. \"gbk\"). The last line states Complete, Partial, or Killed.",
         annotations(
             title = "Run bash command",
             read_only_hint = false,

--- a/tests/property_contract.rs
+++ b/tests/property_contract.rs
@@ -124,7 +124,7 @@ fn independent_o200k_oracle_keeps_high_entropy_outputs_below_the_budget() {
         "{batch_output}"
     );
     let pending_json = batch_terminal
-        .strip_prefix("(Partial: 0 of 3 entries processed. Continue with files=")
+        .strip_prefix("(Partial: 1 entry in progress, 3 requested. Continue with files=")
         .and_then(|terminal| terminal.strip_suffix(".)"))
         .unwrap_or_else(|| panic!("unexpected batch terminal: {batch_terminal}"));
     assert!(
@@ -138,6 +138,8 @@ fn independent_o200k_oracle_keeps_high_entropy_outputs_below_the_budget() {
     assert_eq!(pending.len(), 3);
     let next_offset = pending[0]["offset"].as_u64().unwrap() as usize;
     assert!(next_offset > 1);
+    // The continuation's limit counts the requested window (50 lines starting at
+    // offset 1), not the file, and is dropped once the window is exhausted.
     assert_eq!(pending[0]["limit"], 50 - (next_offset - 1));
     assert_eq!(pending[0]["encoding"], "utf-8");
     assert_eq!(pending[1]["path"], normalized(&batch_second));

--- a/tests/server_contract.rs
+++ b/tests/server_contract.rs
@@ -270,7 +270,7 @@ fn shell_and_replace_tool_descriptions_and_schemas_match_the_frozen_contract() {
             "inspect_local_file.\n",
             "Default timeout 120000 ms, ceiling 240000 — start anything that may outlast\n",
             "it with run_background. If output looks garbled (U+FFFD), pass encoding\n",
-            "(e.g. \"gbk\"). The last line states Complete or Partial."
+            "(e.g. \"gbk\"). The last line states Complete, Partial, or Killed."
         ))
     );
     assert_eq!(run.input_schema["required"], serde_json::json!(["command"]));

--- a/tests/shell_contract.rs
+++ b/tests/shell_contract.rs
@@ -184,7 +184,7 @@ fn foreground_timeout_kills_descendants_and_keeps_captured_output() {
     assert_eq!(response["result"]["isError"], false);
     assert_eq!(
         mcp_text(&response),
-        "started\n\n(Partial: timed out after 2000 ms and the process tree was killed; 1 line captured. Increase timeout_ms or use run_background.)"
+        "started\n\n(Killed: timed out after 2000 ms and the process tree was killed; 1 line captured. Re-run with a larger timeout_ms or use run_background.)"
     );
     assert!(
         spawned.exists(),


### PR DESCRIPTION
## Summary

Fixes the two halves of #32:

**A. `run` timeout is no longer reported as `(Partial: ...)`.**
A timeout kill is not a truncation: the process tree is dead and there is nothing to page. Agents read the Partial prefix as "pageable" and tried to continue reading a process that no longer existed. Timeout kills now emit a third terminal state:

```
(Killed: timed out after 1500 ms and the process tree was killed; 1 line captured. Re-run with a larger timeout_ms or use run_background.)
```

Windowed truncation of a live or exited command keeps `(Partial: ...)` unchanged.

**B. `inspect_local_file` batch no longer undercounts processed entries.**
The tally was derived from the continuation array's length, so one budget break reported every earlier, fully delivered entry as unprocessed. Reproduced on v0.2.6: two entries where the first (huge) one delivers 153 lines before the budget breaks produced

```
(Partial: 0 of 2 entries processed. ...)
```

The response now tracks delivered entries explicitly and reports the partially shown one as in progress:

```
(Partial: 1 entry in progress, 2 requested. Continue with files=[...])
```

Also fixes `progress_after` carrying a stale limit into continuations when the requested window ran past EOF (`checked_sub(shown)` counted delivered lines, not the requested window); the remainder now counts the window and drops once exhausted.

## Supporting changes

- `background_status.rs::insert_status_line` and `server_support.rs::guarded_response_metadata` recognize the new `(Killed:` prefix, so background status lines still land above the terminal note and guarded burst stubs keep their metadata.
- The `run` tool description now says the last line states Complete, Partial, or Killed.

## Testing

- Full suite green locally (209 unit tests + all contract suites), including updated assertions in `shell_contract.rs` (timeout kill wording) and `property_contract.rs` (new tally format).
- End-to-end verified against real Codex CLI 0.147.0 / gpt-5.6-sol over stdio MCP with this branch built as the server binary:
  - timeout kill → `(Killed: ...)`, model correctly identified the state;
  - normal exit → `(Complete: exited 0; no output.)` unchanged;
  - the #32 reproduction (huge entry first, budget break) → `(Partial: 1 entry in progress, 2 requested ...)` instead of `0 of 2 entries processed`.

Happy to split B into its own PR if you prefer to take them separately.